### PR TITLE
Introduce a mine.* options schema and delete the hardcoded identity

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,6 @@
   };
   outputs = { self, darwin, nix-homebrew, homebrew-bundle, homebrew-core, homebrew-cask, deskflowHomebrewTap, openfgaTap, home-manager, nixpkgs, agenix, secrets } @inputs:
     let
-      user = "david";
       system = "aarch64-darwin";
       pkgs = nixpkgs.legacyPackages.${system};
       devShell = {
@@ -69,9 +68,11 @@
         modules = [
           home-manager.darwinModules.home-manager
           nix-homebrew.darwinModules.nix-homebrew
-          {
+          # Homebrew is owned by the machine's user, so this needs the config
+          # rather than a flake-level `let` binding.
+          ({ config, ... }: {
             nix-homebrew = {
-              inherit user;
+              user = config.mine.user.name;
               enable = true;
               taps = {
                 "homebrew/homebrew-core" = homebrew-core;
@@ -83,7 +84,7 @@
               mutableTaps = false;
               autoMigrate = true;
             };
-          }
+          })
           ./hosts/common/darwin.nix
           (./hosts + "/${hostName}")
         ];

--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -4,11 +4,15 @@
 # so `nix run .#build-switch` picks this host with no argument.
 #
 # hosts/common/darwin.nix is composed in by flake.nix; this file holds only
-# what is specific to this machine. That is currently nothing: the user name,
-# the package lists and the work-specific bits are still hardcoded in modules/,
-# and move here as the options schema (#2), the enable flags (#3) and the
-# package lists (#9) land.
+# what is specific to this machine: currently the identity that used to be
+# duplicated as `let user = "david"` across five module files (#2). The enable
+# flags (#3) and the package lists (#9) move here as those issues land.
 { ... }:
 
 {
+  mine.user = {
+    name = "david";
+    fullName = "David";
+    email = "superd001@gmail.com";
+  };
 }

--- a/hosts/common/darwin.nix
+++ b/hosts/common/darwin.nix
@@ -5,6 +5,7 @@ let user = "david"; in
 {
 
   imports = [
+    ../../modules/options.nix
     ../../modules/secrets.nix
     ../../modules/home-manager.nix
     ../../modules/services

--- a/hosts/common/darwin.nix
+++ b/hosts/common/darwin.nix
@@ -1,7 +1,5 @@
 { agenix, config, pkgs, ... }:
 
-let user = "david"; in
-
 {
 
   imports = [
@@ -67,7 +65,7 @@ let user = "david"; in
 
   system = {
     stateVersion = 4;
-    primaryUser = user;
+    primaryUser = config.mine.user.name;
     defaults = {
       NSGlobalDomain = {
         AppleShowAllExtensions = true;

--- a/hosts/example/default.nix
+++ b/hosts/example/default.nix
@@ -3,12 +3,21 @@
 # It exists so the repo has a non-personal host that still evaluates, which is
 # what CI (#10) checks and what the setup wizard (#5) copies.
 #
-# It is deliberately empty rather than artificially rich: until the options
-# schema (#2), the enable flags (#3) and the package lists (#9) exist, there is
-# nothing a generic host can set that would differ from the real one. It is not
-# derived from hosts/David-M3-Pro and is meant to diverge from it as those
-# issues land.
+# The identity below is a deliberate placeholder rather than a default on the
+# options themselves: `mine.user.*` has no defaults, so a fork that forgets to
+# set them fails with an error naming the option instead of silently building
+# as david. This host sets obvious junk so `.#example` keeps evaluating —
+# `nix flake show`, `nix flake check` and CI all need it to — while being
+# visibly wrong to anyone who actually tries to build it.
+#
+# It is not derived from hosts/David-M3-Pro and is meant to diverge from it as
+# the enable flags (#3) and the package lists (#9) land.
 { ... }:
 
 {
+  mine.user = {
+    name = "changeme";
+    fullName = "Change Me";
+    email = "you@example.com";
+  };
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -23,7 +23,9 @@ in
   # Enable home-manager
   home-manager = {
     useGlobalPkgs = true;
-    users.${user} = { pkgs, config, lib, ... }:{
+    users.${user} = { pkgs, config, lib, ... }: {
+      imports = [ ./programs.nix ];
+
       home = {
         enableNixpkgsReleaseCheck = false;
         packages = pkgs.callPackage ./home-packages.nix {};
@@ -31,7 +33,6 @@ in
 
         stateVersion = "23.11";
       };
-      programs = {} // import ./programs.nix { inherit config pkgs lib; };
 
       # Marked broken Oct 20, 2022 check later to remove this
       # https://github.com/nix-community/home-manager/issues/3344

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, home-manager, ... }:
 
 let
-  user = "david";
+  user = config.mine.user.name;
   # Define the content of your file as a derivation
 
   homeFiles = import ./files.nix { inherit config pkgs; };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,0 +1,42 @@
+# The `mine.*` namespace: everything about this repo that is a property of the
+# person or the machine rather than of the software being configured.
+#
+# It is declared with the module system rather than passed around as
+# `specialArgs` on purpose: options get types, error messages that name the
+# option that is missing, and a schema that the setup wizard (#5) can read back
+# and render as prompts.
+#
+# Identity has no defaults. A fork that forgets to set `mine.user.name` gets a
+# loud "option ... is used but not defined" naming the option, instead of a
+# machine quietly configured as david.
+{ lib, ... }:
+
+{
+  options.mine.user = {
+    name = lib.mkOption {
+      type = lib.types.str;
+      example = "ada";
+      description = ''
+        Unix account name. Used for the macOS user, the home directory, the
+        home-manager user, `system.primaryUser` and the Homebrew owner, so it
+        must match the account you actually log in as.
+      '';
+    };
+
+    fullName = lib.mkOption {
+      type = lib.types.str;
+      example = "Ada Lovelace";
+      description = ''
+        Human-readable name, as it should appear in commit authorship.
+      '';
+    };
+
+    email = lib.mkOption {
+      type = lib.types.str;
+      example = "ada@example.com";
+      description = ''
+        Email address used for commit authorship.
+      '';
+    };
+  };
+}

--- a/modules/programs.nix
+++ b/modules/programs.nix
@@ -1,577 +1,579 @@
-{ config, pkgs, lib, ... }:
+# home-manager module. `config` here is the home-manager user config;
+# `osConfig` is the nix-darwin system config, which is where the `mine.*`
+# identity lives.
+{ config, osConfig, pkgs, lib, ... }:
 
-let name = "David";
-    user = "david";
-    email = "superd001@gmail.com"; in
 {
-  # Shared shell configuration
-  zsh = {
-    enable = true;
-    # autocd = false;
-    # cdpath = [ "~/.local/share/src" ];
-    # plugins = [];
-    enableCompletion = false;
-    # enableGlobalCompInit = false;
-
-    # Set the keymap explicitly. Left unset, zsh infers it from $EDITOR — we
-    # export EDITOR="vim" below, so it was silently landing in `viins` while
-    # /etc/zshrc (skipped via NOSYSZSHRC) was no longer there to `bindkey -e`.
-    # That gave the worst of both: no vi motions (they live in vicmd, behind
-    # Esc) and no emacs conveniences either. Deliberate vi mode now, with the
-    # useful emacs bindings grafted into insert mode — see initContent below.
-    defaultKeymap = "viins";
-    # Skip /etc/zshrc entirely — its `autoload -U compinit && compinit` races
-    # on stale ~/.zcompdump.* files and stalls interactive shell startup by 60s+,
-    # which causes VS Code's extension host to time out. We reimplement the
-    # essentials (brew shellenv, fast compinit) in initContent below.
-    envExtra = ''
-      export NOSYSZSHRC=1
-    '';
-    initContent = lib.mkMerge [
-    (lib.mkBefore ''
-      if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
-        . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-        . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
-      fi
-
-      # Replacements for /etc/zshrc (skipped via NOSYSZSHRC in envExtra).
-      eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || true)"
-      autoload -Uz compinit && compinit -C
-      autoload -Uz bashcompinit && bashcompinit
-
-      # Define variables for directories
-      export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
-      export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
-      export PATH=$HOME/.local/bin:$PATH
-
-      # Remove history data we don't want to see
-      export HISTIGNORE="pwd:ls:cd"
-
-      # Ripgrep alias
-      alias search=rg -p --glob '!node_modules/*'  $@
-
-      # Emacs is my editor
-      export ALTERNATE_EDITOR=""
-      export EDITOR="vim"
-      export VISUAL="vim"
-
-      # nix shortcuts
-      shell() {
-          nix-shell '<nixpkgs>' -A "$1"
-      }
-
-      # pnpm is a javascript package manager
-      alias pn=pnpm
-      alias px=pnpx
-
-      # Use difftastic, syntax-aware diffing
-      alias diff=difft
-
-      # Always color ls and group directories
-      alias ls='ls --color=auto'
-
-      # mise version manager — shims-only PATH (no `activate` precmd hook,
-      # which blocked interactive prompts and stalled zsh -ic startup).
-      export PATH="$HOME/.local/share/mise/shims:$PATH"
-
-      # Pick up & export secrets
-      for file in ~/.secrets/*; do
-        [[ -f "$file" ]] && export "''${file##*/}=$(<"$file")"
-      done
-
-      # WeMaintain staging DB helper
-      withPg() {
-        local host=wemaintain-pgsql-staging.cdtgkxemrw9j.eu-west-1.rds.amazonaws.com
-        local user=backend_dev
-        local password
-        password=$(aws rds --profile prod:back generate-db-auth-token --hostname "$host" --port 5432 --region eu-west-1 --username "$user")
-        DB_HOST=$host \
-        POSTGRES_HOST=$host \
-        DB_USER=$user \
-        POSTGRES_USERNAME=$user \
-        DB_PASSWORD=$password \
-        POSTGRES_PASSWORD=$password \
-        DB_SSL_CA=~/.aws/rds-ca-cert.pem \
-        "$@"
-      }
-
-      # WeMaintain production DB helper
-      withPgProd() {
-        local host=wemaintain-pgsql-prod.cdtgkxemrw9j.eu-west-1.rds.amazonaws.com
-        local user=backend_dev
-        local password
-        password=$(aws rds --profile prod:sudo generate-db-auth-token --hostname "$host" --port 5432 --region eu-west-1 --username "$user")
-        DB_HOST=$host \
-        POSTGRES_HOST=$host \
-        DB_USER=$user \
-        POSTGRES_USERNAME=$user \
-        DB_PASSWORD=$password \
-        POSTGRES_PASSWORD=$password \
-        DB_SSL_CA=~/.aws/rds-ca-cert.pem \
-        "$@"
-      }
-    '')
-
-    # Line editing. `defaultKeymap = "viins"` above emits `bindkey -v` at order
-    # 530; this block runs last so nothing can clobber it.
-    #
-    # Esc gives you the full vi command keymap (w/b/e, 0/^/$, dw, ciw, /search
-    # + n/N). Insert mode keeps the emacs conveniences so day-to-day typing is
-    # never worse than before — everything below is bound with `-M viins` so it
-    # only applies while inserting and leaves vicmd's vi grammar untouched.
-    (lib.mkAfter ''
-      # Esc is a prefix for the arrow escape sequences, so zsh waits KEYTIMEOUT
-      # hundredths of a second after Esc to disambiguate. Default 40 = a 0.4s
-      # lag every time you leave insert mode. 1 makes mode switching instant.
-      KEYTIMEOUT=1
-
-      # --- Mode indicator -----------------------------------------------------
-      # vi mode is unusable when you can't see which mode you're in. Beam cursor
-      # = insert, block = command.
-      function _vi-cursor-beam  { print -n '\e[6 q' }
-      function _vi-cursor-block { print -n '\e[2 q' }
-
-      function zle-keymap-select {
-        case $KEYMAP in
-          vicmd)      _vi-cursor-block ;;
-          viins|main) _vi-cursor-beam  ;;
-        esac
-      }
-      zle -N zle-keymap-select
-
-      # Every new prompt starts in insert mode; reset the cursor before running
-      # a command too, so full-screen programs don't inherit a beam.
-      function zle-line-init { _vi-cursor-beam }
-      zle -N zle-line-init
-      autoload -Uz add-zsh-hook
-      add-zsh-hook preexec _vi-cursor-beam
-
-      # --- Insert-mode conveniences (emacs bindings, viins only) --------------
-      # Word motion: Option/Alt + Left/Right. Terminals disagree on what these
-      # emit, so bind every common sequence.
-      bindkey -M viins '^[[1;3D' backward-word   # alt-left  (xterm)
-      bindkey -M viins '^[[1;3C' forward-word    # alt-right (xterm)
-      bindkey -M viins '^[[1;5D' backward-word   # ctrl-left (VS Code, Warp)
-      bindkey -M viins '^[[1;5C' forward-word    # ctrl-right
-      bindkey -M viins '^[^[[D'  backward-word   # esc-prefixed (Terminal.app)
-      bindkey -M viins '^[^[[C'  forward-word
-      bindkey -M viins '^[b'     backward-word
-      bindkey -M viins '^[f'     forward-word
-
-      # Line motion: Cmd + Left/Right, Home/End, and ^A/^E.
-      bindkey -M viins '^[[H'  beginning-of-line
-      bindkey -M viins '^[[F'  end-of-line
-      bindkey -M viins '^[OH'  beginning-of-line
-      bindkey -M viins '^[OF'  end-of-line
-      bindkey -M viins '^[[1~' beginning-of-line
-      bindkey -M viins '^[[4~' end-of-line
-      bindkey -M viins '^A'    beginning-of-line
-      bindkey -M viins '^E'    end-of-line
-
-      # Deletion. vi-backward-delete-char refuses to delete past the point where
-      # insert mode began — the single most confusing viins default. Use the
-      # emacs variants instead.
-      bindkey -M viins '^?'     backward-delete-char   # backspace
-      bindkey -M viins '^H'     backward-delete-char
-      bindkey -M viins '^W'     backward-kill-word
-      bindkey -M viins '^U'     backward-kill-line
-      bindkey -M viins '^K'     kill-line
-      bindkey -M viins '^[[3~'  delete-char            # fn-delete / Del
-      bindkey -M viins '^[^?'   backward-kill-word     # alt-backspace
-      bindkey -M viins '^[[3;3~' kill-word             # alt-del
-
-      # History search. In vicmd you also get vi's native `/pattern` + n/N.
-      bindkey -M viins '^R' history-incremental-search-backward
-      bindkey -M viins '^S' history-incremental-search-forward
-      bindkey -M vicmd '^R' history-incremental-search-backward
-
-      # Prefix-aware history on Up/Down and on vi's k/j: type `git ` then Up
-      # cycles only past git commands.
-      autoload -Uz up-line-or-beginning-search down-line-or-beginning-search
-      zle -N up-line-or-beginning-search
-      zle -N down-line-or-beginning-search
-      for _km in viins vicmd; do
-        bindkey -M $_km '^[[A' up-line-or-beginning-search
-        bindkey -M $_km '^[[B' down-line-or-beginning-search
-        bindkey -M $_km '^[OA' up-line-or-beginning-search
-        bindkey -M $_km '^[OB' down-line-or-beginning-search
-      done
-      unset _km
-      bindkey -M vicmd 'k' up-line-or-beginning-search
-      bindkey -M vicmd 'j' down-line-or-beginning-search
-
-      # --- vi extras ----------------------------------------------------------
-      # `vv` in command mode opens the current line in $EDITOR; :wq runs it.
-      autoload -Uz edit-command-line
-      zle -N edit-command-line
-      bindkey -M vicmd 'vv' edit-command-line
-
-      # Text objects: ci" di( ca' etc. work on quotes and brackets like in vim.
-      autoload -Uz select-quoted select-bracketed
-      zle -N select-quoted
-      zle -N select-bracketed
-      for _km in viopp visual; do
-        for _c in {a,i}''${(s..)^:-\'\"\`\|,./:;=+@}; do
-          bindkey -M $_km $_c select-quoted
-        done
-        for _c in {a,i}''${(s..)^:-'()[]{}<>bB'}; do
-          bindkey -M $_km $_c select-bracketed
-        done
-      done
-      unset _km _c
-    '')
-    ];
-  };
-
-  starship = {
-    enable = true;
-    settings = {
-      add_newline = false;
-      command_timeout = 300;
-
-      character = {
-        success_symbol = "[➜](bold green)";
-        error_symbol = "[➜](bold red)";
-      };
-
-      directory = {
-        truncation_length = 5;
-        truncate_to_repo = false;
-      };
-
-      git_branch = {
-        symbol = " ";
-        disabled = true;
-      };
-
-      git_status = {
-        ahead = ''⇡''${count}'';
-        diverged = ''⇕⇡''${ahead_count}⇣''${behind_count}'';
-        behind = ''⇣''${count}'';
-        disabled = true;
-      };
-
-      nodejs = {
-        symbol = " ";
-        disabled = true;
-      };
-      python = {
-        symbol = " ";
-        disabled = true;
-      };
-      rust = {
-        symbol = " ";
-        disabled = true;
-      };
-      nix_shell = {
-        symbol = " ";
-        impure_msg = "[impure](bold red)";
-        pure_msg = "[pure](bold green)";
-        unknown_msg = "[unknown shell](bold yellow)";
-        format = "via [$symbol$state( \\($name\\))](bold blue) ";
-        disabled = true;
-      };
-    };
-  };
-
-  git = {
-    enable = true;
-    ignores = [ "*.swp" ];
-    signing.format = "openpgp";
-    lfs = {
+  programs = {
+    # Shared shell configuration
+    zsh = {
       enable = true;
-    };
-    settings = {
-      user = {
-        name = name;
-        email = email;
-      };
-      init.defaultBranch = "main";
-      core = {
-	    editor = "vim";
-        autocrlf = "input";
-      };
-      commit.gpgsign = true;
-      pull.rebase = true;
-      rebase.autoStash = true;
-    };
-  };
+      # autocd = false;
+      # cdpath = [ "~/.local/share/src" ];
+      # plugins = [];
+      enableCompletion = false;
+      # enableGlobalCompInit = false;
 
-  vim = {
-    enable = true;
-    plugins = with pkgs.vimPlugins; [ vim-airline vim-airline-themes vim-startify vim-tmux-navigator ];
-    settings = { ignorecase = true; };
-    extraConfig = ''
-      "" General
-      set number
-      set history=1000
-      set nocompatible
-      set modelines=0
-      set encoding=utf-8
-      set scrolloff=3
-      set showmode
-      set showcmd
-      set hidden
-      set wildmenu
-      set wildmode=list:longest
-      set cursorline
-      set ttyfast
-      set nowrap
-      set ruler
-      set backspace=indent,eol,start
-      set laststatus=2
-      set clipboard=autoselect
-
-      " Dir stuff
-      set nobackup
-      set nowritebackup
-      set noswapfile
-      set backupdir=~/.config/vim/backups
-      set directory=~/.config/vim/swap
-
-      " Relative line numbers for easy movement
-      set relativenumber
-      set rnu
-
-      "" Whitespace rules
-      set tabstop=8
-      set shiftwidth=2
-      set softtabstop=2
-      set expandtab
-
-      "" Searching
-      set incsearch
-      set gdefault
-
-      "" Statusbar
-      set nocompatible " Disable vi-compatibility
-      set laststatus=2 " Always show the statusline
-      let g:airline_theme='bubblegum'
-      let g:airline_powerline_fonts = 1
-
-      "" Local keys and such
-      let mapleader=","
-      let maplocalleader=" "
-
-      "" Change cursor on mode
-      :autocmd InsertEnter * set cul
-      :autocmd InsertLeave * set nocul
-
-      "" File-type highlighting and configuration
-      syntax on
-      filetype on
-      filetype plugin on
-      filetype indent on
-
-      "" Paste from clipboard
-      nnoremap <Leader>, "+gP
-
-      "" Copy from clipboard
-      xnoremap <Leader>. "+y
-
-      "" Move cursor by display lines when wrapping
-      nnoremap j gj
-      nnoremap k gk
-
-      "" Map leader-q to quit out of window
-      nnoremap <leader>q :q<cr>
-
-      "" Move around split
-      nnoremap <C-h> <C-w>h
-      nnoremap <C-j> <C-w>j
-      nnoremap <C-k> <C-w>k
-      nnoremap <C-l> <C-w>l
-
-      "" Easier to yank entire line
-      nnoremap Y y$
-
-      "" Move buffers
-      nnoremap <tab> :bnext<cr>
-      nnoremap <S-tab> :bprev<cr>
-
-      "" Like a boss, sudo AFTER opening the file to write
-      cmap w!! w !sudo tee % >/dev/null
-
-      let g:startify_lists = [
-        \ { 'type': 'dir',       'header': ['   Current Directory '. getcwd()] },
-        \ { 'type': 'sessions',  'header': ['   Sessions']       },
-        \ { 'type': 'bookmarks', 'header': ['   Bookmarks']      }
-        \ ]
-
-      let g:startify_bookmarks = [
-        \ '~/.local/share/src',
-        \ ]
-
-      let g:airline_theme='bubblegum'
-      let g:airline_powerline_fonts = 1
+      # Set the keymap explicitly. Left unset, zsh infers it from $EDITOR — we
+      # export EDITOR="vim" below, so it was silently landing in `viins` while
+      # /etc/zshrc (skipped via NOSYSZSHRC) was no longer there to `bindkey -e`.
+      # That gave the worst of both: no vi motions (they live in vicmd, behind
+      # Esc) and no emacs conveniences either. Deliberate vi mode now, with the
+      # useful emacs bindings grafted into insert mode — see initContent below.
+      defaultKeymap = "viins";
+      # Skip /etc/zshrc entirely — its `autoload -U compinit && compinit` races
+      # on stale ~/.zcompdump.* files and stalls interactive shell startup by 60s+,
+      # which causes VS Code's extension host to time out. We reimplement the
+      # essentials (brew shellenv, fast compinit) in initContent below.
+      envExtra = ''
+        export NOSYSZSHRC=1
       '';
-     };
+      initContent = lib.mkMerge [
+      (lib.mkBefore ''
+        if [[ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]]; then
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          . /nix/var/nix/profiles/default/etc/profile.d/nix.sh
+        fi
 
-  alacritty = {
-    enable = true;
-    settings = {
-      cursor = {
-        style = "Block";
-      };
+        # Replacements for /etc/zshrc (skipped via NOSYSZSHRC in envExtra).
+        eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || true)"
+        autoload -Uz compinit && compinit -C
+        autoload -Uz bashcompinit && bashcompinit
 
-      window = {
-        opacity = 1.0;
-        padding = {
-          x = 24;
-          y = 24;
+        # Define variables for directories
+        export PATH=$HOME/.pnpm-packages/bin:$HOME/.pnpm-packages:$PATH
+        export PATH=$HOME/.npm-packages/bin:$HOME/bin:$PATH
+        export PATH=$HOME/.local/bin:$PATH
+
+        # Remove history data we don't want to see
+        export HISTIGNORE="pwd:ls:cd"
+
+        # Ripgrep alias
+        alias search=rg -p --glob '!node_modules/*'  $@
+
+        # Emacs is my editor
+        export ALTERNATE_EDITOR=""
+        export EDITOR="vim"
+        export VISUAL="vim"
+
+        # nix shortcuts
+        shell() {
+            nix-shell '<nixpkgs>' -A "$1"
+        }
+
+        # pnpm is a javascript package manager
+        alias pn=pnpm
+        alias px=pnpx
+
+        # Use difftastic, syntax-aware diffing
+        alias diff=difft
+
+        # Always color ls and group directories
+        alias ls='ls --color=auto'
+
+        # mise version manager — shims-only PATH (no `activate` precmd hook,
+        # which blocked interactive prompts and stalled zsh -ic startup).
+        export PATH="$HOME/.local/share/mise/shims:$PATH"
+
+        # Pick up & export secrets
+        for file in ~/.secrets/*; do
+          [[ -f "$file" ]] && export "''${file##*/}=$(<"$file")"
+        done
+
+        # WeMaintain staging DB helper
+        withPg() {
+          local host=wemaintain-pgsql-staging.cdtgkxemrw9j.eu-west-1.rds.amazonaws.com
+          local user=backend_dev
+          local password
+          password=$(aws rds --profile prod:back generate-db-auth-token --hostname "$host" --port 5432 --region eu-west-1 --username "$user")
+          DB_HOST=$host \
+          POSTGRES_HOST=$host \
+          DB_USER=$user \
+          POSTGRES_USERNAME=$user \
+          DB_PASSWORD=$password \
+          POSTGRES_PASSWORD=$password \
+          DB_SSL_CA=~/.aws/rds-ca-cert.pem \
+          "$@"
+        }
+
+        # WeMaintain production DB helper
+        withPgProd() {
+          local host=wemaintain-pgsql-prod.cdtgkxemrw9j.eu-west-1.rds.amazonaws.com
+          local user=backend_dev
+          local password
+          password=$(aws rds --profile prod:sudo generate-db-auth-token --hostname "$host" --port 5432 --region eu-west-1 --username "$user")
+          DB_HOST=$host \
+          POSTGRES_HOST=$host \
+          DB_USER=$user \
+          POSTGRES_USERNAME=$user \
+          DB_PASSWORD=$password \
+          POSTGRES_PASSWORD=$password \
+          DB_SSL_CA=~/.aws/rds-ca-cert.pem \
+          "$@"
+        }
+      '')
+
+      # Line editing. `defaultKeymap = "viins"` above emits `bindkey -v` at order
+      # 530; this block runs last so nothing can clobber it.
+      #
+      # Esc gives you the full vi command keymap (w/b/e, 0/^/$, dw, ciw, /search
+      # + n/N). Insert mode keeps the emacs conveniences so day-to-day typing is
+      # never worse than before — everything below is bound with `-M viins` so it
+      # only applies while inserting and leaves vicmd's vi grammar untouched.
+      (lib.mkAfter ''
+        # Esc is a prefix for the arrow escape sequences, so zsh waits KEYTIMEOUT
+        # hundredths of a second after Esc to disambiguate. Default 40 = a 0.4s
+        # lag every time you leave insert mode. 1 makes mode switching instant.
+        KEYTIMEOUT=1
+
+        # --- Mode indicator -----------------------------------------------------
+        # vi mode is unusable when you can't see which mode you're in. Beam cursor
+        # = insert, block = command.
+        function _vi-cursor-beam  { print -n '\e[6 q' }
+        function _vi-cursor-block { print -n '\e[2 q' }
+
+        function zle-keymap-select {
+          case $KEYMAP in
+            vicmd)      _vi-cursor-block ;;
+            viins|main) _vi-cursor-beam  ;;
+          esac
+        }
+        zle -N zle-keymap-select
+
+        # Every new prompt starts in insert mode; reset the cursor before running
+        # a command too, so full-screen programs don't inherit a beam.
+        function zle-line-init { _vi-cursor-beam }
+        zle -N zle-line-init
+        autoload -Uz add-zsh-hook
+        add-zsh-hook preexec _vi-cursor-beam
+
+        # --- Insert-mode conveniences (emacs bindings, viins only) --------------
+        # Word motion: Option/Alt + Left/Right. Terminals disagree on what these
+        # emit, so bind every common sequence.
+        bindkey -M viins '^[[1;3D' backward-word   # alt-left  (xterm)
+        bindkey -M viins '^[[1;3C' forward-word    # alt-right (xterm)
+        bindkey -M viins '^[[1;5D' backward-word   # ctrl-left (VS Code, Warp)
+        bindkey -M viins '^[[1;5C' forward-word    # ctrl-right
+        bindkey -M viins '^[^[[D'  backward-word   # esc-prefixed (Terminal.app)
+        bindkey -M viins '^[^[[C'  forward-word
+        bindkey -M viins '^[b'     backward-word
+        bindkey -M viins '^[f'     forward-word
+
+        # Line motion: Cmd + Left/Right, Home/End, and ^A/^E.
+        bindkey -M viins '^[[H'  beginning-of-line
+        bindkey -M viins '^[[F'  end-of-line
+        bindkey -M viins '^[OH'  beginning-of-line
+        bindkey -M viins '^[OF'  end-of-line
+        bindkey -M viins '^[[1~' beginning-of-line
+        bindkey -M viins '^[[4~' end-of-line
+        bindkey -M viins '^A'    beginning-of-line
+        bindkey -M viins '^E'    end-of-line
+
+        # Deletion. vi-backward-delete-char refuses to delete past the point where
+        # insert mode began — the single most confusing viins default. Use the
+        # emacs variants instead.
+        bindkey -M viins '^?'     backward-delete-char   # backspace
+        bindkey -M viins '^H'     backward-delete-char
+        bindkey -M viins '^W'     backward-kill-word
+        bindkey -M viins '^U'     backward-kill-line
+        bindkey -M viins '^K'     kill-line
+        bindkey -M viins '^[[3~'  delete-char            # fn-delete / Del
+        bindkey -M viins '^[^?'   backward-kill-word     # alt-backspace
+        bindkey -M viins '^[[3;3~' kill-word             # alt-del
+
+        # History search. In vicmd you also get vi's native `/pattern` + n/N.
+        bindkey -M viins '^R' history-incremental-search-backward
+        bindkey -M viins '^S' history-incremental-search-forward
+        bindkey -M vicmd '^R' history-incremental-search-backward
+
+        # Prefix-aware history on Up/Down and on vi's k/j: type `git ` then Up
+        # cycles only past git commands.
+        autoload -Uz up-line-or-beginning-search down-line-or-beginning-search
+        zle -N up-line-or-beginning-search
+        zle -N down-line-or-beginning-search
+        for _km in viins vicmd; do
+          bindkey -M $_km '^[[A' up-line-or-beginning-search
+          bindkey -M $_km '^[[B' down-line-or-beginning-search
+          bindkey -M $_km '^[OA' up-line-or-beginning-search
+          bindkey -M $_km '^[OB' down-line-or-beginning-search
+        done
+        unset _km
+        bindkey -M vicmd 'k' up-line-or-beginning-search
+        bindkey -M vicmd 'j' down-line-or-beginning-search
+
+        # --- vi extras ----------------------------------------------------------
+        # `vv` in command mode opens the current line in $EDITOR; :wq runs it.
+        autoload -Uz edit-command-line
+        zle -N edit-command-line
+        bindkey -M vicmd 'vv' edit-command-line
+
+        # Text objects: ci" di( ca' etc. work on quotes and brackets like in vim.
+        autoload -Uz select-quoted select-bracketed
+        zle -N select-quoted
+        zle -N select-bracketed
+        for _km in viopp visual; do
+          for _c in {a,i}''${(s..)^:-\'\"\`\|,./:;=+@}; do
+            bindkey -M $_km $_c select-quoted
+          done
+          for _c in {a,i}''${(s..)^:-'()[]{}<>bB'}; do
+            bindkey -M $_km $_c select-bracketed
+          done
+        done
+        unset _km _c
+      '')
+      ];
+    };
+
+    starship = {
+      enable = true;
+      settings = {
+        add_newline = false;
+        command_timeout = 300;
+
+        character = {
+          success_symbol = "[➜](bold green)";
+          error_symbol = "[➜](bold red)";
         };
-      };
 
-      font = {
-        normal = {
-          family = "MesloLGS NF";
-          style = "Regular";
-        };
-        size = 14;
-      };
-
-      dynamic_padding = true;
-      decorations = "full";
-      title = "Terminal";
-      class = {
-        instance = "Alacritty";
-        general = "Alacritty";
-      };
-
-      colors = {
-        primary = {
-          background = "0x1f2528";
-          foreground = "0xc0c5ce";
+        directory = {
+          truncation_length = 5;
+          truncate_to_repo = false;
         };
 
-        normal = {
-          black = "0x1f2528";
-          red = "0xec5f67";
-          green = "0x99c794";
-          yellow = "0xfac863";
-          blue = "0x6699cc";
-          magenta = "0xc594c5";
-          cyan = "0x5fb3b3";
-          white = "0xc0c5ce";
+        git_branch = {
+          symbol = " ";
+          disabled = true;
         };
 
-        bright = {
-          black = "0x65737e";
-          red = "0xec5f67";
-          green = "0x99c794";
-          yellow = "0xfac863";
-          blue = "0x6699cc";
-          magenta = "0xc594c5";
-          cyan = "0x5fb3b3";
-          white = "0xd8dee9";
+        git_status = {
+          ahead = ''⇡''${count}'';
+          diverged = ''⇕⇡''${ahead_count}⇣''${behind_count}'';
+          behind = ''⇣''${count}'';
+          disabled = true;
+        };
+
+        nodejs = {
+          symbol = " ";
+          disabled = true;
+        };
+        python = {
+          symbol = " ";
+          disabled = true;
+        };
+        rust = {
+          symbol = " ";
+          disabled = true;
+        };
+        nix_shell = {
+          symbol = " ";
+          impure_msg = "[impure](bold red)";
+          pure_msg = "[pure](bold green)";
+          unknown_msg = "[unknown shell](bold yellow)";
+          format = "via [$symbol$state( \\($name\\))](bold blue) ";
+          disabled = true;
         };
       };
     };
+
+    git = {
+      enable = true;
+      ignores = [ "*.swp" ];
+      signing.format = "openpgp";
+      lfs = {
+        enable = true;
+      };
+      settings = {
+        user = {
+          name = osConfig.mine.user.fullName;
+          email = osConfig.mine.user.email;
+        };
+        init.defaultBranch = "main";
+        core = {
+  	    editor = "vim";
+          autocrlf = "input";
+        };
+        commit.gpgsign = true;
+        pull.rebase = true;
+        rebase.autoStash = true;
+      };
+    };
+
+    vim = {
+      enable = true;
+      plugins = with pkgs.vimPlugins; [ vim-airline vim-airline-themes vim-startify vim-tmux-navigator ];
+      settings = { ignorecase = true; };
+      extraConfig = ''
+        "" General
+        set number
+        set history=1000
+        set nocompatible
+        set modelines=0
+        set encoding=utf-8
+        set scrolloff=3
+        set showmode
+        set showcmd
+        set hidden
+        set wildmenu
+        set wildmode=list:longest
+        set cursorline
+        set ttyfast
+        set nowrap
+        set ruler
+        set backspace=indent,eol,start
+        set laststatus=2
+        set clipboard=autoselect
+
+        " Dir stuff
+        set nobackup
+        set nowritebackup
+        set noswapfile
+        set backupdir=~/.config/vim/backups
+        set directory=~/.config/vim/swap
+
+        " Relative line numbers for easy movement
+        set relativenumber
+        set rnu
+
+        "" Whitespace rules
+        set tabstop=8
+        set shiftwidth=2
+        set softtabstop=2
+        set expandtab
+
+        "" Searching
+        set incsearch
+        set gdefault
+
+        "" Statusbar
+        set nocompatible " Disable vi-compatibility
+        set laststatus=2 " Always show the statusline
+        let g:airline_theme='bubblegum'
+        let g:airline_powerline_fonts = 1
+
+        "" Local keys and such
+        let mapleader=","
+        let maplocalleader=" "
+
+        "" Change cursor on mode
+        :autocmd InsertEnter * set cul
+        :autocmd InsertLeave * set nocul
+
+        "" File-type highlighting and configuration
+        syntax on
+        filetype on
+        filetype plugin on
+        filetype indent on
+
+        "" Paste from clipboard
+        nnoremap <Leader>, "+gP
+
+        "" Copy from clipboard
+        xnoremap <Leader>. "+y
+
+        "" Move cursor by display lines when wrapping
+        nnoremap j gj
+        nnoremap k gk
+
+        "" Map leader-q to quit out of window
+        nnoremap <leader>q :q<cr>
+
+        "" Move around split
+        nnoremap <C-h> <C-w>h
+        nnoremap <C-j> <C-w>j
+        nnoremap <C-k> <C-w>k
+        nnoremap <C-l> <C-w>l
+
+        "" Easier to yank entire line
+        nnoremap Y y$
+
+        "" Move buffers
+        nnoremap <tab> :bnext<cr>
+        nnoremap <S-tab> :bprev<cr>
+
+        "" Like a boss, sudo AFTER opening the file to write
+        cmap w!! w !sudo tee % >/dev/null
+
+        let g:startify_lists = [
+          \ { 'type': 'dir',       'header': ['   Current Directory '. getcwd()] },
+          \ { 'type': 'sessions',  'header': ['   Sessions']       },
+          \ { 'type': 'bookmarks', 'header': ['   Bookmarks']      }
+          \ ]
+
+        let g:startify_bookmarks = [
+          \ '~/.local/share/src',
+          \ ]
+
+        let g:airline_theme='bubblegum'
+        let g:airline_powerline_fonts = 1
+        '';
+       };
+
+    alacritty = {
+      enable = true;
+      settings = {
+        cursor = {
+          style = "Block";
+        };
+
+        window = {
+          opacity = 1.0;
+          padding = {
+            x = 24;
+            y = 24;
+          };
+        };
+
+        font = {
+          normal = {
+            family = "MesloLGS NF";
+            style = "Regular";
+          };
+          size = 14;
+        };
+
+        dynamic_padding = true;
+        decorations = "full";
+        title = "Terminal";
+        class = {
+          instance = "Alacritty";
+          general = "Alacritty";
+        };
+
+        colors = {
+          primary = {
+            background = "0x1f2528";
+            foreground = "0xc0c5ce";
+          };
+
+          normal = {
+            black = "0x1f2528";
+            red = "0xec5f67";
+            green = "0x99c794";
+            yellow = "0xfac863";
+            blue = "0x6699cc";
+            magenta = "0xc594c5";
+            cyan = "0x5fb3b3";
+            white = "0xc0c5ce";
+          };
+
+          bright = {
+            black = "0x65737e";
+            red = "0xec5f67";
+            green = "0x99c794";
+            yellow = "0xfac863";
+            blue = "0x6699cc";
+            magenta = "0xc594c5";
+            cyan = "0x5fb3b3";
+            white = "0xd8dee9";
+          };
+        };
+      };
+    };
+
+    ssh = {
+      enable = true;
+      enableDefaultConfig = false;
+      includes = [
+        "${config.home.homeDirectory}/.ssh/config_external"
+      ];
+      # Upstream OpenSSH directive names — `matchBlocks` (and its camelCase
+      # aliases / `extraOptions` escape hatch) is deprecated.
+      settings = {
+        "*" = {
+          AddKeysToAgent = "yes";
+        };
+        "github.com" = {
+          IdentitiesOnly = true;
+          IdentityFile = [
+            "${config.home.homeDirectory}/.ssh/id_rsa"
+          ];
+        };
+      };
+    };
+
+    tmux = {
+      enable = false;
+      plugins = with pkgs.tmuxPlugins; [
+        vim-tmux-navigator
+        sensible
+        yank
+        prefix-highlight
+        {
+          plugin = power-theme;
+          extraConfig = ''
+             set -g @tmux_power_theme 'gold'
+          '';
+        }
+        {
+          plugin = resurrect; # Used by tmux-continuum
+
+          # Use XDG data directory
+          # https://github.com/tmux-plugins/tmux-resurrect/issues/348
+          extraConfig = ''
+            set -g @resurrect-dir '$HOME/.cache/tmux/resurrect'
+            set -g @resurrect-capture-pane-contents 'on'
+            set -g @resurrect-pane-contents-area 'visible'
+          '';
+        }
+        {
+          plugin = continuum;
+          extraConfig = ''
+            set -g @continuum-restore 'on'
+            set -g @continuum-save-interval '5' # minutes
+          '';
+        }
+      ];
+      terminal = "screen-256color";
+      prefix = "C-x";
+      escapeTime = 10;
+      historyLimit = 50000;
+      extraConfig = ''
+        # Remove Vim mode delays
+        set -g focus-events on
+
+        # Enable full mouse support
+        set -g mouse on
+
+        # -----------------------------------------------------------------------------
+        # Key bindings
+        # -----------------------------------------------------------------------------
+
+        # Unbind default keys
+        unbind C-b
+        unbind '"'
+        unbind %
+
+        # Split panes, vertical or horizontal
+        bind-key x split-window -v
+        bind-key v split-window -h
+
+        # Move around panes with vim-like bindings (h,j,k,l)
+        bind-key -n M-k select-pane -U
+        bind-key -n M-h select-pane -L
+        bind-key -n M-j select-pane -D
+        bind-key -n M-l select-pane -R
+
+        # Smart pane switching with awareness of Vim splits.
+        # This is copy paste from https://github.com/christoomey/vim-tmux-navigator
+        is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
+          | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
+        bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
+        bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
+        bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
+        bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
+        tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
+        if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
+          "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
+        if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
+          "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
+
+        bind-key -T copy-mode-vi 'C-h' select-pane -L
+        bind-key -T copy-mode-vi 'C-j' select-pane -D
+        bind-key -T copy-mode-vi 'C-k' select-pane -U
+        bind-key -T copy-mode-vi 'C-l' select-pane -R
+        bind-key -T copy-mode-vi 'C-\' select-pane -l
+        '';
+      };
+
   };
-
-  ssh = {
-    enable = true;
-    enableDefaultConfig = false;
-    includes = [
-      "/Users/${user}/.ssh/config_external"
-    ];
-    # Upstream OpenSSH directive names — `matchBlocks` (and its camelCase
-    # aliases / `extraOptions` escape hatch) is deprecated.
-    settings = {
-      "*" = {
-        AddKeysToAgent = "yes";
-      };
-      "github.com" = {
-        IdentitiesOnly = true;
-        IdentityFile = [
-          "/Users/${user}/.ssh/id_rsa"
-        ];
-      };
-    };
-  };
-
-  tmux = {
-    enable = false;
-    plugins = with pkgs.tmuxPlugins; [
-      vim-tmux-navigator
-      sensible
-      yank
-      prefix-highlight
-      {
-        plugin = power-theme;
-        extraConfig = ''
-           set -g @tmux_power_theme 'gold'
-        '';
-      }
-      {
-        plugin = resurrect; # Used by tmux-continuum
-
-        # Use XDG data directory
-        # https://github.com/tmux-plugins/tmux-resurrect/issues/348
-        extraConfig = ''
-          set -g @resurrect-dir '$HOME/.cache/tmux/resurrect'
-          set -g @resurrect-capture-pane-contents 'on'
-          set -g @resurrect-pane-contents-area 'visible'
-        '';
-      }
-      {
-        plugin = continuum;
-        extraConfig = ''
-          set -g @continuum-restore 'on'
-          set -g @continuum-save-interval '5' # minutes
-        '';
-      }
-    ];
-    terminal = "screen-256color";
-    prefix = "C-x";
-    escapeTime = 10;
-    historyLimit = 50000;
-    extraConfig = ''
-      # Remove Vim mode delays
-      set -g focus-events on
-
-      # Enable full mouse support
-      set -g mouse on
-
-      # -----------------------------------------------------------------------------
-      # Key bindings
-      # -----------------------------------------------------------------------------
-
-      # Unbind default keys
-      unbind C-b
-      unbind '"'
-      unbind %
-
-      # Split panes, vertical or horizontal
-      bind-key x split-window -v
-      bind-key v split-window -h
-
-      # Move around panes with vim-like bindings (h,j,k,l)
-      bind-key -n M-k select-pane -U
-      bind-key -n M-h select-pane -L
-      bind-key -n M-j select-pane -D
-      bind-key -n M-l select-pane -R
-
-      # Smart pane switching with awareness of Vim splits.
-      # This is copy paste from https://github.com/christoomey/vim-tmux-navigator
-      is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
-        | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|n?vim?x?)(diff)?$'"
-      bind-key -n 'C-h' if-shell "$is_vim" 'send-keys C-h'  'select-pane -L'
-      bind-key -n 'C-j' if-shell "$is_vim" 'send-keys C-j'  'select-pane -D'
-      bind-key -n 'C-k' if-shell "$is_vim" 'send-keys C-k'  'select-pane -U'
-      bind-key -n 'C-l' if-shell "$is_vim" 'send-keys C-l'  'select-pane -R'
-      tmux_version='$(tmux -V | sed -En "s/^tmux ([0-9]+(.[0-9]+)?).*/\1/p")'
-      if-shell -b '[ "$(echo "$tmux_version < 3.0" | bc)" = 1 ]' \
-        "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\'  'select-pane -l'"
-      if-shell -b '[ "$(echo "$tmux_version >= 3.0" | bc)" = 1 ]' \
-        "bind-key -n 'C-\\' if-shell \"$is_vim\" 'send-keys C-\\\\'  'select-pane -l'"
-
-      bind-key -T copy-mode-vi 'C-h' select-pane -L
-      bind-key -T copy-mode-vi 'C-j' select-pane -D
-      bind-key -T copy-mode-vi 'C-k' select-pane -U
-      bind-key -T copy-mode-vi 'C-l' select-pane -R
-      bind-key -T copy-mode-vi 'C-\' select-pane -l
-      '';
-    };
-
 }

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -1,17 +1,20 @@
 { config, pkgs, agenix, secrets, ... }:
 
-let user = "david"; in
+let
+  user = config.mine.user.name;
+  home = config.users.users.${user}.home;
+in
 {
   age.identityPaths = [
-    "/Users/${user}/.ssh/id_ed25519"
+    "${home}/.ssh/id_ed25519"
   ];
 
   age.secrets.GITHUB_NPM_TOKEN = {
     symlink = true;
-    path = "/Users/${user}/.secrets/GITHUB_TOKEN";
+    path = "${home}/.secrets/GITHUB_TOKEN";
     file = "${secrets}/github-npm-token.age";
     mode = "600";
-    owner = "${user}";
+    owner = user;
     group = "staff";
   };
 


### PR DESCRIPTION
Closes #2.

## Before

`user = "david"` was a `let` binding repeated in five files, with `name = "David"` and `email = "superd001@gmail.com"` in a sixth spot — seven copies of identity, nothing keeping them in sync:

| file | what it fed |
| --- | --- |
| `flake.nix:41` | `nix-homebrew.user` |
| `hosts/common/darwin.nix:3` | `system.primaryUser` |
| `modules/home-manager.nix:4` | the macOS user, its home dir, the home-manager user attr |
| `modules/programs.nix:4` | two `/Users/${user}` ssh paths |
| `modules/secrets.nix:3` | the agenix identity path, the secret target and its owner |
| `modules/programs.nix:3,5` | git author name and email |

`hosts/David-M3-Pro/` and `hosts/example/` (added by #11) were both `{ ... }: { }` plus a comment saying they'd get content once this landed.

## After

`modules/options.nix` declares `mine.user.{name,fullName,email}` with `mkOption`, `types.str`, examples and descriptions, and **no defaults**. Every consumer reads `config.mine.user.*`, or `osConfig.mine.user.*` in home-manager scope. The real values live in `hosts/David-M3-Pro/default.nix`; `hosts/example/default.nix` sets placeholders.

Options rather than `specialArgs`, per the issue: types, an error that names the missing option, and a schema the wizard (#5) can read back as prompts.

### Two things that needed care

**`modules/programs.nix` could not see the system config.** It was invoked as a plain function call from inside the home-manager user module — `programs = {} // import ./programs.nix { inherit config pkgs lib; }` — so its `config` was home-manager's and `config.mine.user.email` would never have resolved. I converted it into a real home-manager module listed in `imports`, which gets it `osConfig`. Passing the values in as arguments would also have worked, but this is the shape the file wants anyway and #1 splits it into per-program modules from here. The two `/Users/${user}` ssh paths became `${config.home.homeDirectory}`, which home-manager already derives from the same place.

The body is now nested under `programs = { ... }`, so the file is reindented by two spaces and the diff looks enormous. **`git diff -w` on that file is 10 insertions / 8 deletions** — and the drvPath check below proves the reindent changed no string values.

**`flake.nix`'s nix-homebrew block** was already an inline module, so it just takes `{ config, ... }` and reads `config.mine.user.name`. No recursion: `mine.user.name` does not depend on anything nix-homebrew defines. Verified by evaluating.

`modules/secrets.nix` derives its paths from `config.users.users.<name>.home` rather than rebuilding `/Users/${user}` by hand, so there's one definition of where home is.

## This settles the identity question #11 deferred

#11 left open whether a fork inherits a default identity. It does not.

The options have no defaults, so an unconfigured host fails loudly:

```
$ nix eval --raw .#darwinConfigurations.example.system.drvPath   # with mine.user unset
error:
       … while evaluating the option `mine.user.name':
       error: The option `mine.user.name' was accessed but has no value defined. Try setting the option.
```

But a flake output that fails to evaluate breaks `nix flake show`, `nix flake check` and the CI planned in #10, so `hosts/example/default.nix` sets visible junk (`name = "changeme"`, `email = "you@example.com"`). `.#example` stays evaluatable, nobody silently inherits David's identity, and the placeholder is obviously wrong to anyone who builds it. No eval-time assertion is added, for the same reason — it would make `.#example` unevaluatable again.

## Verification

Pure refactor of David's machine; the built system must not change.

```
$ export NIXPKGS_ALLOW_UNFREE=1
$ nix eval --raw .#darwinConfigurations.David-M3-Pro.system.drvPath
```

| tree | drvPath |
| --- | --- |
| `origin/main` (clean worktree) | `/nix/store/fa6a1r614km4v9ssgq6fqj3a3py0sd60-darwin-system-26.11.a4cf1d1.drv` |
| this branch | `/nix/store/fa6a1r614km4v9ssgq6fqj3a3py0sd60-darwin-system-26.11.a4cf1d1.drv` |

Byte-identical. Each of the four commits individually evaluates to that same path, so the branch bisects cleanly and the `programs.nix` reindent is provably value-preserving.

The example host evaluates and is now a genuinely different machine:

```
$ nix eval --raw .#darwinConfigurations.example.system.drvPath
/nix/store/73bcbr8l41brycprpb786w4277iizkbr-darwin-system-26.11.a4cf1d1.drv
```

Apps still build:

```
$ nix build --no-link .#build .#build-switch .#rollback
$ echo $?
0
```

## Not in scope

Enable flags (#3), package lists (#9), splitting `modules/programs.nix` per program (#1), and any `mine.*` beyond `user` — later issues add their own.

Two `/Users/david` strings survive and are deliberately left alone: `modules/desktop/betterdisplay/betterdisplaycli.nix` hardcodes the repo checkout location (a path assumption, not identity) and `modules/services/screen-lock-monitor/default.nix` uses `com.david.screen-lock-monitor` as a launchd label. Both want their own change.