### PR TITLE
Add mkEnableOption flags so opt-in modules can be turned off from the host

### DIFF
--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -4,9 +4,10 @@
 # so `nix run .#build-switch` picks this host with no argument.
 #
 # hosts/common/darwin.nix is composed in by flake.nix; this file holds only
-# what is specific to this machine: currently the identity that used to be
-# duplicated as `let user = "david"` across five module files (#2). The enable
-# flags (#3) and the package lists (#9) move here as those issues land.
+# what is specific to this machine: the identity that used to be duplicated as
+# `let user = "david"` across five module files (#2), and the enable flags that
+# used to be hardcoded inside the modules themselves (#3). The package lists
+# (#9) move here as that issue lands.
 { ... }:
 
 {
@@ -15,4 +16,27 @@
     fullName = "David";
     email = "superd001@gmail.com";
   };
+
+  # Every flag below is spelled out even where it looks obvious. `mkEnableOption`
+  # defaults to `false`, so nothing arrives here by default and nothing can drift
+  # back in by someone changing a default in modules/. What this machine runs is
+  # readable in one screen, which is the whole point.
+  mine.desktop = {
+    # Tiling window manager. The reason this laptop exists in this shape.
+    aerospace.enable = true;
+
+    # Off. It was previously off via `services.sketchybar.enable = false` inside
+    # modules/desktop/sketchybar/sketchybar.nix; same end state, expressed here.
+    sketchybar.enable = false;
+
+    # The /usr/local/bin shims for the BetterDisplay cask, plus
+    # workspace-to-next-monitor, which aerospace binds to.
+    betterdisplay.enable = true;
+
+    # On: this config manages the Dock. Which today means stripping it, since
+    # `local.dock.enable` is false and the entries list is empty.
+    dock.enable = true;
+  };
+
+  mine.services."screen-lock-monitor".enable = true;
 }

--- a/hosts/example/default.nix
+++ b/hosts/example/default.nix
@@ -11,7 +11,7 @@
 # visibly wrong to anyone who actually tries to build it.
 #
 # It is not derived from hosts/David-M3-Pro and is meant to diverge from it as
-# the enable flags (#3) and the package lists (#9) land.
+# the package lists (#9) land.
 { ... }:
 
 {
@@ -20,4 +20,30 @@
     fullName = "Change Me";
     email = "you@example.com";
   };
+
+  # A plain machine. The flags default to `false`, so this block only has to
+  # say what a generic fork should get; anything left out is off.
+  mine.desktop = {
+    # On. It is the one opinionated thing in this repo that is worth arriving
+    # switched on, and it keeps CI evaluating a desktop module in its enabled
+    # branch rather than only its disabled one.
+    aerospace.enable = true;
+
+    # Off. A status bar is a taste, not a default.
+    sketchybar.enable = false;
+
+    # Off. The activation script writes to /usr/local/bin and still hardcodes a
+    # /Users/david path (#4); it also only makes sense with the BetterDisplay
+    # cask actually installed.
+    betterdisplay.enable = false;
+
+    # Off. With `local.dock.enable` false this would strip the Dock bare on
+    # first activation, which is not something a fork should discover by
+    # surprise.
+    dock.enable = false;
+  };
+
+  # Off. A launchd agent labelled com.david.* watching lock events is not a
+  # generic want.
+  mine.services."screen-lock-monitor".enable = false;
 }

--- a/modules/desktop/aerospace/aerospace.nix
+++ b/modules/desktop/aerospace/aerospace.nix
@@ -1,6 +1,10 @@
-{lib, ...}: {
-  services.aerospace = {
-    enable = true;
-    settings = lib.importTOML ./.aerospace.toml;
+{ config, lib, ... }:
+
+{
+  config = lib.mkIf config.mine.desktop.aerospace.enable {
+    services.aerospace = {
+      enable = true;
+      settings = lib.importTOML ./.aerospace.toml;
+    };
   };
 }

--- a/modules/desktop/betterdisplay/betterdisplaycli.nix
+++ b/modules/desktop/betterdisplay/betterdisplaycli.nix
@@ -1,12 +1,14 @@
-{ config, lib, pkgs, ... }:
+{ config, lib, ... }:
 
 {
-  system.activationScripts.extraActivation.text = ''
-    cat > /usr/local/bin/betterdisplaycli << 'EOF'
-    #!/bin/bash
-    exec /Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay "$@"
-    EOF
-    chmod +x /usr/local/bin/betterdisplaycli
-    ln -f /Users/david/.config/nixos-config/modules/desktop/betterdisplay/next-monitor-of-workspace.sh /usr/local/bin/workspace-to-next-monitor
-  '';
+  config = lib.mkIf config.mine.desktop.betterdisplay.enable {
+    system.activationScripts.extraActivation.text = ''
+      cat > /usr/local/bin/betterdisplaycli << 'EOF'
+      #!/bin/bash
+      exec /Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay "$@"
+      EOF
+      chmod +x /usr/local/bin/betterdisplaycli
+      ln -f /Users/david/.config/nixos-config/modules/desktop/betterdisplay/next-monitor-of-workspace.sh /usr/local/bin/workspace-to-next-monitor
+    '';
+  };
 }

--- a/modules/desktop/dock.nix
+++ b/modules/desktop/dock.nix
@@ -35,7 +35,12 @@ in
       };
   };
 
-  config =
+  # `mine.desktop.dock.enable` is the outer switch: whether this config manages
+  # the Dock at all. `local.dock.enable` below is the inner one: given that we
+  # are managing it, do we populate it from `entries` or strip it bare. Leaving
+  # the outer switch off means the Dock is left exactly as the user arranged it,
+  # which is the right default on a machine that is not mine.
+  config = mkIf config.mine.desktop.dock.enable (
     mkMerge [
       (mkIf (cfg.enable) (
         let
@@ -82,5 +87,6 @@ in
             echo >&2 "Dock removed"
         '';
       })
-    ];
+    ]
+  );
 }

--- a/modules/desktop/sketchybar/sketchybar.nix
+++ b/modules/desktop/sketchybar/sketchybar.nix
@@ -1,5 +1,12 @@
-_ : {
-  services.sketchybar = {
-    enable = false;
+# SketchyBar. This used to read `services.sketchybar.enable = false;` right
+# here, which is the anti-pattern #3 exists to remove: the only way to turn it
+# on was to edit a file upstream also maintains. The switch now lives on the
+# host as `mine.desktop.sketchybar.enable`, and this module only ever turns the
+# service on.
+{ config, lib, ... }:
+
+{
+  config = lib.mkIf config.mine.desktop.sketchybar.enable {
+    services.sketchybar.enable = true;
   };
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -39,4 +39,46 @@
       '';
     };
   };
+
+  # Opt-in units (#3). Everything under here is a `mkEnableOption`, so it
+  # defaults to `false` and a host has to ask for it by name. That is the point:
+  # a fork that copies hosts/example gets a machine with nothing exotic turned
+  # on, and turning something off is one line in the host file rather than an
+  # edit to a module that upstream also maintains.
+  #
+  # The modules themselves are always imported by modules/desktop/default.nix
+  # and modules/services/default.nix; only their `config` is gated. Import lists
+  # stay static so the wizard (#5) never has to rewrite one.
+  options.mine.desktop = {
+    aerospace.enable = lib.mkEnableOption ''
+      the AeroSpace tiling window manager, configured from
+      modules/desktop/aerospace/.aerospace.toml
+    '';
+
+    sketchybar.enable = lib.mkEnableOption ''
+      the SketchyBar status bar
+    '';
+
+    betterdisplay.enable = lib.mkEnableOption ''
+      the BetterDisplay helper scripts: a `betterdisplaycli` shim and
+      `workspace-to-next-monitor`, both installed into /usr/local/bin by an
+      activation script. Needs the `betterdisplay` cask, which is currently
+      listed in modules/homebrew.nix (#9 moves that here)
+    '';
+
+    dock.enable = lib.mkEnableOption ''
+      declarative management of the macOS Dock. When on, the Dock is either
+      populated from `local.dock.entries` or stripped entirely, depending on
+      `local.dock.enable`. When off, this config does not touch the Dock at all,
+      which is what you want on a machine whose Dock someone else arranged
+    '';
+  };
+
+  options.mine.services = {
+    # Hyphenated to match the launchd label and the directory it lives in.
+    "screen-lock-monitor".enable = lib.mkEnableOption ''
+      the screen-lock-monitor launchd agent, a small Swift binary built from
+      modules/services/screen-lock-monitor that watches macOS lock/unlock events
+    '';
+  };
 }

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -1,5 +1,26 @@
-_ : {
+# Services are imported unconditionally and gated on their `mine.services.*`
+# flag, so the wizard (#5) never has to rewrite an import list.
+#
+# screen-lock-monitor is gated from out here rather than from inside its own
+# file, which is the one exception to that shape and is deliberate. Its
+# derivation uses `src = ./.`, so every file in
+# modules/services/screen-lock-monitor is a build input — the .nix file
+# included. Putting `lib.mkIf` in there would change the source hash and force a
+# recompile of the Swift binary, and of everything downstream of it, for a
+# refactor that changes nothing about what runs.
+#
+# The gate is an inline module inside `imports` rather than a `config` block on
+# this file, and that also matters: module order decides the order in which
+# `environment.systemPackages` is concatenated, and system-path hashes that
+# order. Sitting in the import list keeps the wrapper exactly where
+# ./screen-lock-monitor used to sit, so the closure is unchanged.
+{ config, lib, pkgs, ... }:
+
+{
   imports = [
-    ./screen-lock-monitor
+    {
+      config = lib.mkIf config.mine.services."screen-lock-monitor".enable
+        (import ./screen-lock-monitor { inherit pkgs; });
+    }
   ];
 }


### PR DESCRIPTION
Closes #3

Every opt-in unit now has an `mkEnableOption` under `mine.*`, and every module body is wrapped in `lib.mkIf`. Turning something off is a line in `hosts/<hostname>/default.nix`; nothing under `modules/` needs editing, and no import list changes. That is the constraint the setup wizard (#5) needs in order to be safe to run on a stranger's machine.

## Flags added

All five are declared in `modules/options.nix`, next to `mine.user`.

| Flag | Default | David-M3-Pro | example |
|---|---|---|---|
| `mine.desktop.aerospace.enable` | `false` | `true` | `true` |
| `mine.desktop.sketchybar.enable` | `false` | `false` | `false` |
| `mine.desktop.betterdisplay.enable` | `false` | `true` | `false` |
| `mine.desktop.dock.enable` | `false` | `true` | `false` |
| `mine.services."screen-lock-monitor".enable` | `false` | `true` | `false` |

### Why everything defaults off

`mkEnableOption` defaults to `false` and I did not override any of them. That means `David-M3-Pro` has to ask by name for things it used to get for free, and every flag — including the ones that are off — is spelled out in that file. Two reasons:

- The host file is now the single readable answer to "what does this machine run", instead of a list of exceptions to defaults declared five directories away.
- A default that is on can drift back in. If someone later flips a default in `modules/`, a host that never mentioned the flag silently changes. Spelling it out makes that impossible.

The cost is a slightly longer host file. That is the right trade for a repo whose whole point is being forkable.

### `mine.desktop.dock` has two layers, on purpose

`modules/desktop/dock.nix` already had `local.dock.enable`, which chooses between *populate the Dock from `entries`* and *strip the Dock bare*. `mine.desktop.dock.enable` sits outside that and answers a different question: does this config manage the Dock at all? Off means the Dock is left exactly as the user arranged it.

That distinction matters for `example`. `local.dock.enable` is `false` in `modules/home-manager.nix`, so a fork that arrived with dock management on would have its Dock stripped bare on first activation. Hence `example` gets `dock.enable = false` while `David-M3-Pro` gets `true` — which is what preserves today's behaviour, since the strip branch is what his machine actually runs.

### sketchybar

`modules/desktop/sketchybar/sketchybar.nix` used to be, in its entirety, `services.sketchybar.enable = false;`. That is the exact anti-pattern this issue is about: the module decided its own on/off state, so the only way to turn it on was to edit a file upstream also maintains. The module now only ever turns the service *on*, and the `false` lives in `hosts/David-M3-Pro/default.nix`. Same end state, opposite direction of control.

## drvPath comparison

This is a pure refactor of David's machine, so its built system must be unchanged.

```
$ export NIXPKGS_ALLOW_UNFREE=1
$ nix --extra-experimental-features 'nix-command flakes' eval --raw \
    .#darwinConfigurations.David-M3-Pro.system.drvPath
```

| Ref | drvPath |
|---|---|
| `origin/main` (b9d7aa9) | `/nix/store/fa6a1r614km4v9ssgq6fqj3a3py0sd60-darwin-system-26.11.a4cf1d1.drv` |
| this branch (13bb32a) | `/nix/store/fa6a1r614km4v9ssgq6fqj3a3py0sd60-darwin-system-26.11.a4cf1d1.drv` |

Byte-identical.

`.#darwinConfigurations.example.system` also evaluates, to `/nix/store/mskcyaqwgxrinh1knvn7fwkj3iyvvl09-darwin-system-26.11.a4cf1d1.drv`.

### It took two attempts, and both failures are worth recording

**First: `src = ./.` swallows the module file.** The obvious change — put `lib.mkIf` in `modules/services/screen-lock-monitor/default.nix` — rebuilt the world. That derivation uses `src = ./.`, so every file in the directory is a build input, including the `.nix` file that defines the derivation. Editing it changed the Swift binary's source hash, and with it the launchd plist, `/etc`, `system-applications` and the system closure. So the gate had to live outside that directory, and `modules/services/screen-lock-monitor/` is untouched in this PR.

**Second: module position decides `systemPackages` order.** Moving the gate into `modules/services/default.nix` as a plain `config` block still changed the hash. Diffing the two `system-path.drv` files showed identical package sets in a different order — `screen-lock-monitor` had moved from index 0 to index 4, ahead of `brew` but now behind `darwin-uninstaller`/`darwin-version`/`darwin-rebuild`/`darwin-option`. `system-path` hashes that order, so same packages, different hash, pointless full rebuild.

The fix is that the gate is an inline module inside `imports` rather than a `config` block on the file:

```nix
imports = [
  {
    config = lib.mkIf config.mine.services."screen-lock-monitor".enable
      (import ./screen-lock-monitor { inherit pkgs; });
  }
];
```

Sitting in the import list keeps the wrapper in exactly the slot `./screen-lock-monitor` used to occupy. Both reasons are commented in the file so the next person does not rediscover them.

## What a forker can turn off now that they couldn't before

Before this, all five of these were reachable only by editing files under `modules/`:

- **aerospace** — hardcoded `services.aerospace.enable = true`, removable only by deleting the import from `modules/desktop/default.nix`.
- **sketchybar** — hardcoded off inside its own module; turning it *on* required editing the module.
- **betterdisplay** — an unconditional activation script that writes two files into `/usr/local/bin`, one of them hardlinked from a hardcoded `/Users/david` path.
- **dock** — an unconditional activation script that, as configured, wipes the Dock.
- **screen-lock-monitor** — an unconditional Swift build plus a launchd agent labelled `com.david.screen-lock-monitor`.

`hosts/example/default.nix` now demonstrates the subtraction: it keeps aerospace and drops the other four.

## Not in scope

`#9` (package lists to hosts, including "each module brings its own dependencies" — the `betterdisplay` cask still lives in `modules/homebrew.nix`, untouched), `#1` (splitting `modules/programs.nix`), `#4` (the `/Users/david` path in `betterdisplaycli.nix` is preserved verbatim, since changing it would change the activation script).

`modules/options.nix` is appended to, not restructured, to stay mergeable with the `mine.secrets.enable` work happening in parallel on `ci/evaluate-hosts`.
