### PR TITLE
Make secrets optional (#17), then CI that evaluates hosts/example (#10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+# Evaluation CI (#10).
+#
+# `hosts/example` is the seed the setup wizard copies, and nobody runs it day to
+# day, so it rots silently unless something checks it. That is the gap this
+# workflow closes, and it is deliberately the only host here: `David-M3-Pro` is
+# verified every time its owner runs `build-switch`, and evaluating it in CI
+# would mean faking the private `secrets` input it enables — checking a system
+# that is not the one actually built.
+#
+# Evaluation, not building, is what runs on every push: a renamed option, a
+# missing attribute or a typo'd flag is caught by `nix eval` in seconds, while a
+# full build costs a macOS runner many minutes and catches a rarer class of
+# breakage (a dead cask, a broken package). The full build is on a weekly
+# schedule in a separate job, so a slow or flaky build never blocks a PR.
+name: ci
+
+on:
+  # The branch filter is load-bearing, not tidiness: a push to a branch that has
+  # an open PR fires `push` *and* `pull_request`, which is two macOS runners
+  # doing identical work. The concurrency group below does not merge them —
+  # `github.ref` is `refs/heads/<branch>` for one and `refs/pull/<n>/merge` for
+  # the other, so they land in different groups. Restricting `push` to the
+  # default branch gives one run per PR commit and one per merge to main.
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Mondays, 05:00 UTC.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+# A newer push to the same branch makes the older run pointless. (This cancels
+# superseded runs; it is not what prevents the push/PR duplication above.)
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # nixpkgs.config.allowUnfree is set in-tree, but several paths still consult
+  # the environment, and evaluation aborts without it.
+  NIXPKGS_ALLOW_UNFREE: 1
+  # The installer turns these on already; being explicit means a change in its
+  # defaults shows up as nothing at all rather than as a confusing failure.
+  NIX_CONFIG: |
+    experimental-features = nix-command flakes
+
+jobs:
+  # This is also the standing acceptance test for #17: `example` must evaluate
+  # for somebody who has no access to anything private. The job is given no SSH
+  # key and no credentials, and the GIT_SSH_COMMAND below makes any attempt to
+  # reach the private secrets repo fail immediately and loudly instead of
+  # hanging on a prompt. If someone reintroduces an unconditional `${secrets}`
+  # interpolation, this job goes red.
+  eval-example:
+    name: eval hosts/example (no private access)
+    # macos-15 is arm64, matching the flake's aarch64-darwin.
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      # Nix is not preinstalled on GitHub's macOS runners, and this repo assumes
+      # Determinate Nix (hosts/common/darwin.nix sets nix.enable = false).
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Evaluate darwinConfigurations.example.system.drvPath
+        env:
+          # No agent, no identity, no prompts: any private fetch fails here.
+          GIT_SSH_COMMAND: >-
+            ssh -o IdentityAgent=none -o IdentityFile=/dev/null
+            -o IdentitiesOnly=yes -o BatchMode=yes
+        run: |
+          nix eval --raw .#darwinConfigurations.example.system.drvPath
+          echo
+
+  # `nix build` on the app scripts is what runs shellcheck over apps/*.sh:
+  # they are built with writeShellApplication, which shellchecks at build time.
+  apps:
+    name: build app scripts (shellcheck)
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: nix build .#build .#build-switch .#rollback
+        run: nix build --no-link --print-out-paths .#build .#build-switch .#rollback
+
+  # The expensive check: an actual build of the example host, which catches what
+  # evaluation cannot — a package that no longer builds, a cask that vanished.
+  # Weekly only, and never a required check on a PR.
+  build-example:
+    name: build hosts/example (weekly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-15
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v5
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Build hosts/example
+        env:
+          GIT_SSH_COMMAND: >-
+            ssh -o IdentityAgent=none -o IdentityFile=/dev/null
+            -o IdentitiesOnly=yes -o BatchMode=yes
+        run: nix build --no-link .#darwinConfigurations.example.system
+
+# Two checks from #10 are deliberately not here yet, because both would fail on
+# main today and a check that is red the day it merges teaches everyone to
+# ignore CI:
+#
+#   - "no proper nouns in modules/" — depends on #9, which moves the package
+#     lists into hosts/.
+#   - "fail if /Users/david appears outside hosts/" — depends on #4;
+#     modules/desktop/betterdisplay/betterdisplaycli.nix and
+#     modules/services/screen-lock-monitor/default.nix still contain it.
+#
+# Add both as a `grep` job once #4 and #9 land.
+#
+# If CI coverage of the owner's host is ever wanted, the honest mechanism is a
+# deploy key to nix-secrets in a GitHub secret: no fake files in the repo, and a
+# real drvPath. Note that PRs from forks do not receive repo secrets, so such a
+# job needs `continue-on-error` or a trigger that excludes fork PRs.

--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -39,4 +39,7 @@
   };
 
   mine.services."screen-lock-monitor".enable = true;
+
+  # This machine has SSH access to the private secrets repo (#17).
+  mine.secrets.enable = true;
 }

--- a/hosts/example/default.nix
+++ b/hosts/example/default.nix
@@ -46,4 +46,7 @@
   # Off. A launchd agent labelled com.david.* watching lock events is not a
   # generic want.
   mine.services."screen-lock-monitor".enable = false;
+
+  # `mine.secrets.enable` is deliberately left at its default (false): this host
+  # must evaluate with no access to the private secrets repo (#17).
 }

--- a/modules/nixpkgs.nix
+++ b/modules/nixpkgs.nix
@@ -1,7 +1,13 @@
 { config, pkgs, ... }:
 
 let
-  emacsOverlaySha256 = "06413w510jmld20i4lik9b36cfafm501864yq8k4vxl5r4hn0j0h";
+  # Pinned to a commit, not to refs/heads/master: a branch tarball moves, but
+  # the sha256 below does not, so the pair only agreed on machines that already
+  # had the old tarball in their store. Anywhere else — CI, or anyone who forks
+  # this repo — evaluation died with "NAR hash mismatch". This rev is the
+  # content that was already cached, so nothing about what gets built changes.
+  emacsOverlayRev = "9f303ef429e3a6cf0aabedd007e4ea6398a6f67b";
+  emacsOverlaySha256 = "11p1c1l04zrn8dd5w8zyzlv172z05dwi9avbckav4d5fk043m754";
 in
 {
 
@@ -22,7 +28,7 @@ in
                   (attrNames (readDir path)))
 
       ++ [(import (builtins.fetchTarball {
-               url = "https://github.com/dustinlyons/emacs-overlay/archive/refs/heads/master.tar.gz";
+               url = "https://github.com/dustinlyons/emacs-overlay/archive/${emacsOverlayRev}.tar.gz";
                sha256 = emacsOverlaySha256;
            }))];
   };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -81,4 +81,10 @@
       modules/services/screen-lock-monitor that watches macOS lock/unlock events
     '';
   };
+
+  # Off by default: the secrets module interpolates the `secrets` flake input,
+  # which is a private repo. Anything that forces it needs SSH access nobody
+  # but its owner has, so a host has to opt in explicitly (#17).
+  options.mine.secrets.enable =
+    lib.mkEnableOption "agenix-managed secrets from the private `secrets` flake input";
 }

--- a/modules/secrets.nix
+++ b/modules/secrets.nix
@@ -1,10 +1,17 @@
-{ config, pkgs, agenix, secrets, ... }:
+# agenix-managed secrets, read out of the private `secrets` flake input.
+#
+# The whole body is behind `mine.secrets.enable` (default false) because
+# `${secrets}` is a private `git+ssh://` repo: interpolating it forces the
+# fetch, and evaluating *any* host would then require SSH access to it. With
+# the option off the interpolation is never reached, so the input is never
+# fetched and hosts like `example` evaluate for anyone (#17).
+{ config, lib, pkgs, agenix, secrets, ... }:
 
 let
   user = config.mine.user.name;
   home = config.users.users.${user}.home;
 in
-{
+lib.mkIf config.mine.secrets.enable {
   age.identityPaths = [
     "${home}/.ssh/id_ed25519"
   ];


### PR DESCRIPTION
Closes #17
Closes #10

Three commits: #17 first, because CI could not exist without it; then the workflow; then a one-line pin that CI itself uncovered on its first run.

Rebased onto `c06628e` after #18 merged. The conflicts in `modules/options.nix` and both host files were additive on each side and were resolved by keeping both.

## Why #17 was a prerequisite

`modules/secrets.nix` interpolated `${secrets}` — the `git+ssh://git@github.com/superd22/nix-secrets` flake input, a private repo — and `hosts/common/darwin.nix` imported it unconditionally. Interpolating forces the fetch, so evaluating *any* host required SSH access to a repo only its owner can read. No workflow gets around that without a deploy key, and a deploy key papers over the real problem: `hosts/example` is meant to be usable by forkers, and it was not.

`mine.secrets.enable` (default `false`, declared in `modules/options.nix`) now gates the module body via `lib.mkIf`. `hosts/David-M3-Pro` opts in; `hosts/example` leaves it off. The input stays declared in `flake.nix` — flake inputs cannot be conditional — but a disabled module never forces it, so it is never fetched.

## How I proved evaluation works without private-repo access

Two things had to be ruled out: a warm store or eval cache making a broken setup look fine, and a test that cannot actually detect a forced fetch.

**First attempt, rejected.** Evaluating with `--override-input secrets git+ssh://…/this-repo-does-not-exist` fails for *both* hosts — `--override-input` forces a fetch while updating the lock file, before any module is evaluated. It measures the lock update, not the module.

**Second attempt, also rejected.** Evaluating in a throwaway `HOME` (empty `~/.ssh`, empty nix fetcher cache), with `SSH_AUTH_SOCK` unset, `GIT_SSH_COMMAND='ssh -o IdentityAgent=none -o IdentityFile=/dev/null -o IdentitiesOnly=yes -o BatchMode=yes'` and `--option eval-cache false`, succeeded for `example` — but the control, `David-M3-Pro`, succeeded too. The locked input was already in the local store and was served from there. That is exactly the masking effect that makes a warm machine a bad witness.

**The test that discriminates.** Copy the repo, shadow the value handed to the modules with a bomb — `specialArgs = inputs // { secrets = throw "THE SECRETS INPUT WAS FORCED"; }` — and evaluate. No store path or cache can mask this: if any code path forces the input, evaluation aborts. Re-run after the rebase:

    example:      /nix/store/y87zl8pgb5k0p4zmbncm3wikfhiz516p-darwin-system-…drv   (exit 0)
    David-M3-Pro: error: THE SECRETS INPUT WAS FORCED                              (exit 1)

with the failing control's trace ending exactly where it should:

    … while evaluating the option `age.secrets.GITHUB_NPM_TOKEN.file':
    … while evaluating definitions from `…/modules/secrets.nix':
    … while evaluating the module argument `secrets' in "…/modules/secrets.nix"

The control failing is the point: it shows the test can detect a forced fetch, so `example` passing is a real result rather than a test that cannot fail. `example` also produced its *normal* drvPath under the bomb — it never touches the input at all.

**And then the real thing.** A GitHub macOS runner — cold store, no SSH key, no credentials of any kind — evaluated `hosts/example` successfully. That is the claim of #17 demonstrated on a machine that has never had access to anything private.

## The emacs-overlay pin (found by CI, first run)

The first CI run was red, for a reason that had nothing to do with secrets: `modules/nixpkgs.nix` fetched the overlay from `archive/refs/heads/master.tar.gz` with a fixed `sha256`. A branch tarball moves; the hash does not. The two only agreed on a machine that already had the old tarball in its store, so on any cold machine evaluation died before reaching a single module:

    error: NAR hash mismatch in input '…/emacs-overlay/archive/refs/heads/master.tar.gz',
    expected 'sha256-EEhgIcmF…' but got 'sha256-pJw6CJiu…'

This was a *second*, independent reason a forker could not evaluate this flake, and CI cannot be green without fixing it. Pinned to the rev whose contents were already cached (`9f303ef`), so both hosts' drvPaths are byte-identical before and after — verified, not assumed.

## Verification

Baseline computed from a pristine checkout of the new `origin/main` (`c06628e`), not taken on trust:

    origin/main   David-M3-Pro: /nix/store/fa6a1r614km4v9ssgq6fqj3a3py0sd60-darwin-system-…drv
    this branch   David-M3-Pro: /nix/store/fa6a1r614km4v9ssgq6fqj3a3py0sd60-darwin-system-…drv   (identical)

    origin/main   example:      /nix/store/mskcyaqwgxrinh1knvn7fwkj3iyvvl09-darwin-system-…drv
    this branch   example:      /nix/store/y87zl8pgb5k0p4zmbncm3wikfhiz516p-darwin-system-…drv

`David-M3-Pro` is unchanged: the real machine builds exactly what it built before. `example` *does* change, and should — on `main` it had the secrets module forced on, and now it does not.

`nix build --no-link .#build .#build-switch .#rollback` succeeds locally and in CI. `actionlint` 1.7.12 reports no findings.

## Why only `hosts/example` is evaluated

An earlier revision of this PR also evaluated `David-M3-Pro`, by overriding the private input with a stub directory of fake `.age` files. That is gone, along with the stub. Two reasons:

- Every future secret would need a matching fake file, or the job silently goes red. A maintenance tax that grows with each secret.
- Overriding the input means CI evaluates a system that is *not* the one actually built, so it burns a macOS runner checking something adjacent to the truth.

#10's own rationale settles it: "My own `hosts/David-M3-Pro/config.nix` can't rot, because I run it. The example can. CI is what closes that gap." David's host is verified on every `build-switch`. `hosts/example` is what nobody runs, it needs no secrets, and evaluating it needs no override. Nothing in the repo ships a pretend secret.

Note, not a TODO: if CI coverage of the owner's host is ever wanted, the honest mechanism is a deploy key to `nix-secrets` in a GitHub secret — no stub, real drvPath. PRs from forks do not receive repo secrets, so such a job would need `continue-on-error` or a trigger that excludes fork PRs.

## Deferred checks

Two items from #10 are deliberately **not** here, because both fail on `main` today and a check that is red the day it merges just teaches everyone to ignore CI:

- **no proper nouns in `modules/`** — depends on #9, which moves the package lists into `hosts/`.
- **fail if `/Users/david` appears outside `hosts/`** — depends on #4; `modules/desktop/betterdisplay/betterdisplaycli.nix` and `modules/services/screen-lock-monitor/default.nix` still contain it.

Both should be added as a cheap `grep` job the moment #4 and #9 land. There is a note to that effect at the bottom of the workflow.

## Two workflow fixes from watching the early runs

- **One run per commit, not two.** Bare `push:` plus `pull_request:` means a push to a branch with an open PR fires both events — two macOS runners doing identical work. The `concurrency` group does not merge them, because `github.ref` is `refs/heads/<branch>` for the push event and `refs/pull/<n>/merge` for the PR event, so they land in different groups. `push` is now filtered to `branches: [main]`: one run per PR commit, one per merge to `main`. The filter has a comment explaining itself so it does not get "tidied away" later. The concurrency block stays — it still cancels superseded runs on a branch.
- **`actions/checkout@v4` → `@v5`.** The runs warned "Node.js 20 is deprecated … actions/checkout@v4". `DeterminateSystems/nix-installer-action` was checked and is already `using: node24`, so it needs no bump.
