### PR TITLE
fix: purge hardcoded /Users/david paths from the modules

### DIFF
--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -36,6 +36,10 @@
     # On: this config manages the Dock. Which today means stripping it, since
     # `local.dock.enable` is false and the entries list is empty.
     dock.enable = true;
+
+    # The ultra-wide script commands. They drive betterdisplaycli, so this
+    # wants betterdisplay.enable above (#21).
+    raycast.enable = true;
   };
 
   mine.services."screen-lock-monitor".enable = true;

--- a/hosts/example/default.nix
+++ b/hosts/example/default.nix
@@ -32,19 +32,23 @@
     # Off. A status bar is a taste, not a default.
     sketchybar.enable = false;
 
-    # Off. The activation script writes to /usr/local/bin and still hardcodes a
-    # /Users/david path (#4); it also only makes sense with the BetterDisplay
-    # cask actually installed.
+    # Off. The activation script writes to /usr/local/bin, and none of it means
+    # anything without the BetterDisplay cask actually installed.
     betterdisplay.enable = false;
 
     # Off. With `local.dock.enable` false this would strip the Dock bare on
     # first activation, which is not something a fork should discover by
     # surprise.
     dock.enable = false;
+
+    # Off. The scripts here are for one specific ultra-wide monitor, and
+    # wiring them up needs a manual step in Raycast's settings anyway.
+    raycast.enable = false;
   };
 
-  # Off. A launchd agent labelled com.david.* watching lock events is not a
-  # generic want.
+  # Off. A launchd agent watching lock events is not a generic want. The label
+  # follows `mine.user.name` now (#4), so on this host it would be
+  # com.changeme.screen-lock-monitor rather than com.david.*.
   mine.services."screen-lock-monitor".enable = false;
 
   # `mine.secrets.enable` is deliberately left at its default (false): this host

--- a/modules/config/emacs/config.org
+++ b/modules/config/emacs/config.org
@@ -82,10 +82,13 @@ This associates our package manager with the right source (MELPA).
     "Return true if system is GNU/Linux-based"
     (string-equal system-type "gnu/linux"))
 
-  ;; Set path for darwin
+  ;; Set path for darwin. The home-relative entries are expanded at startup so
+  ;; this follows whoever is logged in rather than one hardcoded account.
   (when (system-is-mac)
-    (setenv "PATH" (concat (getenv "PATH") ":/Users/david/.nix-profile/bin:/usr/bin"))
-    (setq exec-path (append '("/Users/david/bin" "/profile/bin" "/Users/david/.npm-packages/bin" "/Users/david/.nix-profile/bin" "/nix/var/nix/profiles/default/bin" "/usr/local/bin" "/usr/bin") exec-path)))
+    (setenv "PATH" (concat (getenv "PATH") ":" (expand-file-name "~/.nix-profile/bin") ":/usr/bin"))
+    (setq exec-path (append (mapcar #'expand-file-name
+                                    '("~/bin" "/profile/bin" "~/.npm-packages/bin" "~/.nix-profile/bin" "/nix/var/nix/profiles/default/bin" "/usr/local/bin" "/usr/bin"))
+                            exec-path)))
 #+END_SRC
 
 *** Counsel/Ivy framework

--- a/modules/config/raycast/readme.md
+++ b/modules/config/raycast/readme.md
@@ -1,13 +1,20 @@
 # Raycast
-Dmenu alternative for macos
 
-Currently everything here needs to be imported manually in raycast...
-scripts/ needs to be defined as "script directory" in raycast
-quicklinks needs to be imported.
+Dmenu alternative for macOS.
+
+`scripts/` is wired up by [`modules/desktop/raycast`](../../desktop/raycast/default.nix),
+which renders each command into `~/.config/raycast/scripts` with a shebang and a
+store-pinned `PATH` prepended. The sources here therefore have no shebang of
+their own and call `aerospace` / `betterdisplaycli` by bare name.
+
+One manual step remains on a fresh machine: in Raycast, Settings ->
+Extensions -> Script Commands -> "Add Script Directory", and pick
+`~/.config/raycast/scripts`. `quicklinks.json` also has to be imported by hand —
+Raycast exposes no on-disk format for quicklinks.
 
 ## Layout
 ```
 .
-├── scripts/              # bash scripts to be created as commands in raycast
+├── scripts/              # bash script commands, rendered into the home by the nix module
 ├── quicklinks.json       # Quicklinks to import to raycast
 ```

--- a/modules/config/raycast/scripts/toggle_option_command.sh
+++ b/modules/config/raycast/scripts/toggle_option_command.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+# Built by modules/desktop/raycast into ~/.config/raycast/scripts, which is
+# where the shebang and the PATH for `aerospace` / `betterdisplaycli` are
+# added; this file is not meant to run straight out of the working tree.
 
 
 # Required parameters:

--- a/modules/config/raycast/scripts/ultra-wide-dualscreen.sh
+++ b/modules/config/raycast/scripts/ultra-wide-dualscreen.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+# Built by modules/desktop/raycast into ~/.config/raycast/scripts, which is
+# where the shebang and the PATH for `aerospace` / `betterdisplaycli` are
+# added; this file is not meant to run straight out of the working tree.
 # @raycast.schemaVersion 1
 # @raycast.title Toggle Ultra-Wide Dual Screen
 # @raycast.mode fullOutput
@@ -9,9 +11,9 @@
 
 # Ensure aerospace is enabled
 echo "Checking aerospace status..."
-if ! /Users/david/.nix-profile/bin/aerospace list-windows --focused &>/dev/null; then
+if ! aerospace list-windows --focused &>/dev/null; then
     echo "Aerospace appears to be disabled. Enabling it..."
-    /Users/david/.nix-profile/bin/aerospace enable on
+    aerospace enable on
     sleep 1
 else
     echo "Aerospace is already enabled."
@@ -42,19 +44,19 @@ if echo "$displays" | betterdisplaycli get -identifiers | paste -sd '\0' - | sed
     betterdisplaycli set -name="Right" -pip=on -targetName="Odyssey G93SC" -originX=50% -originY=0% -width=50% -height=100% -priority=absolute -showTitlebar=off -showShadow=off -unmovable=on -clickthrough=on
 
      # Put everything in odyssey but the pip windows on the left
-     /Users/david/.nix-profile/bin/aerospace list-workspaces --all --format "%{workspace} %{monitor-name}" --json | jq -r '.[] | select(.["monitor-name"] != "Left" and .["monitor-name"] != "Right") | .["workspace"]' | while read -r id; do
-         /Users/david/.nix-profile/bin/aerospace move-workspace-to-monitor --workspace "$id" "Left"
+     aerospace list-workspaces --all --format "%{workspace} %{monitor-name}" --json | jq -r '.[] | select(.["monitor-name"] != "Left" and .["monitor-name"] != "Right") | .["workspace"]' | while read -r id; do
+         aerospace move-workspace-to-monitor --workspace "$id" "Left"
      done
     #  aerospace move-workspace-to-monitor --workspace "1" --monitor "Left"
-# /Users/david/.nix-profile/bin/aerospace list-windows --all --json --format "%{window-id}%{monitor-name}" | jq -r '.[] | select(.["monitor-name"] != "Left" and .["monitor-name"] != "Right") | .["window-id"]' | while read -r id; do
-#     /Users/david/.nix-profile/bin/aerospace move-node-to-monitor --window-id "$id" "Left"
+# aerospace list-windows --all --json --format "%{window-id}%{monitor-name}" | jq -r '.[] | select(.["monitor-name"] != "Left" and .["monitor-name"] != "Right") | .["window-id"]' | while read -r id; do
+#     aerospace move-node-to-monitor --window-id "$id" "Left"
 # done
 
      # Move non-BetterDisplay windows from workspace BD to workspace 1
      echo "Checking for non-BetterDisplay windows in workspace BD..."
-     /Users/david/.nix-profile/bin/aerospace list-windows --workspace BD --json 2>/dev/null | jq -r '.[] | select(.["app-name"] != "BetterDisplay") | .["window-id"]' | while read -r window_id; do
+     aerospace list-windows --workspace BD --json 2>/dev/null | jq -r '.[] | select(.["app-name"] != "BetterDisplay") | .["window-id"]' | while read -r window_id; do
          echo "  Moving non-BetterDisplay window $window_id from workspace BD to workspace 1"
-         /Users/david/.nix-profile/bin/aerospace move-node-to-workspace --window-id "$window_id" 1
+         aerospace move-node-to-workspace --window-id "$window_id" 1
      done
 
      # Restore saved window positions if they exist
@@ -65,7 +67,7 @@ if echo "$displays" | betterdisplaycli get -identifiers | paste -sd '\0' - | sed
              window_id=$(echo "$entry" | jq -r '.window_id')
              workspace=$(echo "$entry" | jq -r '.workspace')
              echo "  Restoring window $window_id to workspace $workspace"
-             /Users/david/.nix-profile/bin/aerospace move-node-to-workspace --window-id "$window_id" "$workspace" 2>/dev/null || true
+             aerospace move-node-to-workspace --window-id "$window_id" "$workspace" 2>/dev/null || true
          done
          echo "Deleting saved window positions file..."
          rm "$TEMP_FILE"
@@ -75,37 +77,37 @@ if echo "$displays" | betterdisplaycli get -identifiers | paste -sd '\0' - | sed
 
      # Move windows from workspaces > 10 to workspace 1
      echo "Checking for windows in workspaces > 10..."
-     /Users/david/.nix-profile/bin/aerospace list-workspaces --all --json | jq -r '.[] | select(.workspace | tonumber? != null and tonumber > 10) | .workspace' | while read -r workspace; do
+     aerospace list-workspaces --all --json | jq -r '.[] | select(.workspace | tonumber? != null and tonumber > 10) | .workspace' | while read -r workspace; do
          echo "Found workspace: $workspace"
-         /Users/david/.nix-profile/bin/aerospace list-windows --workspace "$workspace" --json | jq -r '.[]["window-id"]' | while read -r window_id; do
+         aerospace list-windows --workspace "$workspace" --json | jq -r '.[]["window-id"]' | while read -r window_id; do
              echo "  Moving window $window_id from workspace $workspace to workspace 1"
-             /Users/david/.nix-profile/bin/aerospace move-node-to-workspace --window-id "$window_id" 1
+             aerospace move-node-to-workspace --window-id "$window_id" 1
          done
      done
 
      # Ensure Left and Right monitors are on workspaces <= 10
      echo "Checking monitor workspace assignments..."
-     left_workspace=$(/Users/david/.nix-profile/bin/aerospace list-workspaces --monitor "Left" --json 2>/dev/null | jq -r '.[0].workspace // empty')
-     right_workspace=$(/Users/david/.nix-profile/bin/aerospace list-workspaces --monitor "Right" --json 2>/dev/null | jq -r '.[0].workspace // empty')
+     left_workspace=$(aerospace list-workspaces --monitor "Left" --json 2>/dev/null | jq -r '.[0].workspace // empty')
+     right_workspace=$(aerospace list-workspaces --monitor "Right" --json 2>/dev/null | jq -r '.[0].workspace // empty')
      
      if [ -n "$left_workspace" ] && [ "$left_workspace" -gt 10 ] 2>/dev/null; then
          echo "Left monitor is on workspace $left_workspace (> 10), moving workspace 1 to Left monitor..."
-         /Users/david/.nix-profile/bin/aerospace move-workspace-to-monitor --workspace 1 "Left"
+         aerospace move-workspace-to-monitor --workspace 1 "Left"
      else
          echo "Left monitor is on workspace $left_workspace (OK)"
      fi
      
      if [ -n "$right_workspace" ] && [ "$right_workspace" -gt 10 ] 2>/dev/null; then
          echo "Right monitor is on workspace $right_workspace (> 10), moving workspace 2 to Right monitor..."
-         /Users/david/.nix-profile/bin/aerospace move-workspace-to-monitor --workspace 2 "Right"
+         aerospace move-workspace-to-monitor --workspace 2 "Right"
      else
          echo "Right monitor is on workspace $right_workspace (OK)"
      fi
      
      # Also ensure both workspaces 1 and 2 are on the correct monitors
      echo "Ensuring workspace 1 is on Left and workspace 2 is on Right..."
-     /Users/david/.nix-profile/bin/aerospace move-workspace-to-monitor --workspace 1 "Left" 2>/dev/null || true
-     /Users/david/.nix-profile/bin/aerospace move-workspace-to-monitor --workspace 2 "Right" 2>/dev/null || true
+     aerospace move-workspace-to-monitor --workspace 1 "Left" 2>/dev/null || true
+     aerospace move-workspace-to-monitor --workspace 2 "Right" 2>/dev/null || true
 
 
 

--- a/modules/config/raycast/scripts/ultra-wide-monoscreen.sh
+++ b/modules/config/raycast/scripts/ultra-wide-monoscreen.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+# Built by modules/desktop/raycast into ~/.config/raycast/scripts, which is
+# where the shebang and the PATH for `aerospace` / `betterdisplaycli` are
+# added; this file is not meant to run straight out of the working tree.
 # @raycast.schemaVersion 1
 # @raycast.title Toggle Ultra-Wide Mono Screen
 # @raycast.mode fullOutput
@@ -23,7 +25,7 @@ echo "Saving window positions..."
 TEMP_FILE="/tmp/aerospace-window-positions.json"
 
 # Get all windows from workspaces 0-10 and save their workspace assignments
-/Users/david/.nix-profile/bin/aerospace list-windows --all --json | \
+aerospace list-windows --all --json | \
     jq '[.[] | select(.workspace | tonumber? != null and tonumber >= 0 and tonumber <= 10) | {window_id: ."window-id", workspace: .workspace}]' > "$TEMP_FILE"
 
 echo "Saved $(jq 'length' "$TEMP_FILE") window positions to $TEMP_FILE"
@@ -40,12 +42,12 @@ betterdisplaycli set -name="Odyssey G93SC" -main=on
 
 # 4. Move all windows to workspace BD
 echo "Moving all windows to workspace BD..."
-/Users/david/.nix-profile/bin/aerospace list-windows --all --json | jq -r '.[]["window-id"]' | while read -r window_id; do
-    /Users/david/.nix-profile/bin/aerospace move-node-to-workspace --window-id "$window_id" BD 2>/dev/null
+aerospace list-windows --all --json | jq -r '.[]["window-id"]' | while read -r window_id; do
+    aerospace move-node-to-workspace --window-id "$window_id" BD 2>/dev/null
 done
 
 # 5. Disable aerospace
 echo "Disabling aerospace..."
-/Users/david/.nix-profile/bin/aerospace enable off
+aerospace enable off
 
 echo "Mono screen mode setup complete!"

--- a/modules/desktop/betterdisplay/betterdisplaycli.nix
+++ b/modules/desktop/betterdisplay/betterdisplaycli.nix
@@ -1,14 +1,23 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
+let
+  scripts = import ./scripts.nix { inherit pkgs; };
+in
 {
   config = lib.mkIf config.mine.desktop.betterdisplay.enable {
+    environment.systemPackages = [ scripts.workspace-to-next-monitor ];
+
     system.activationScripts.extraActivation.text = ''
       cat > /usr/local/bin/betterdisplaycli << 'EOF'
       #!/bin/bash
       exec /Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay "$@"
       EOF
       chmod +x /usr/local/bin/betterdisplaycli
-      ln -f /Users/david/.config/nixos-config/modules/desktop/betterdisplay/next-monitor-of-workspace.sh /usr/local/bin/workspace-to-next-monitor
+      # AeroSpace's `exec-and-forget` inherits the PATH of the GUI process that
+      # launched it, which is not guaranteed to include the system profile, so
+      # the keybindings in .aerospace.toml go through an absolute path. The shim
+      # points at the store, not at the working tree.
+      ln -sfn ${scripts.workspace-to-next-monitor}/bin/workspace-to-next-monitor /usr/local/bin/workspace-to-next-monitor
     '';
   };
 }

--- a/modules/desktop/betterdisplay/next-monitor-of-workspace.sh
+++ b/modules/desktop/betterdisplay/next-monitor-of-workspace.sh
@@ -1,9 +1,14 @@
-#!/bin/sh
+# Built by scripts.nix into a writeShellApplication named
+# `workspace-to-next-monitor`; `aerospace` and `jq` come from its runtimeInputs,
+# so this file is not meant to be run straight out of the working tree.
+#
+# Usage: workspace-to-next-monitor <workspace-name>
+# Example: workspace-to-next-monitor 1
+#
+# Sends a workspace to the "other" monitor of the pair: Left <-> Right, and the
+# ultra-wide back to Left. Bound to ctrl-shift-alt-<N> in .aerospace.toml.
 
-# Scripts to get the next monitor of a workspace in BetterDisplay
-# Usage: ./next-monitor-of-workspace.sh <workspace-name>
-# Example: ./next-monitor-of-workspace.sh "1"
-result=$(/Users/david/.nix-profile/bin/aerospace list-workspaces --all --json  --format "%{workspace}%{monitor-name}" | jq -r --arg ws "$1" '
+result=$(aerospace list-workspaces --all --json --format "%{workspace}%{monitor-name}" | jq -r --arg ws "$1" '
   map(select(.workspace == $ws)) | .[0]."monitor-name" as $mon |
   if $mon == "Left" then "Right"
   elif $mon == "Right" then "Left"
@@ -11,6 +16,6 @@ result=$(/Users/david/.nix-profile/bin/aerospace list-workspaces --all --json  -
 else $mon
   end')
 
-if [ ! -z "$result" ]; then
-  /Users/david/.nix-profile/bin/aerospace move-workspace-to-monitor --workspace $1 "$result"
+if [ -n "$result" ]; then
+  aerospace move-workspace-to-monitor --workspace "$1" "$result"
 fi

--- a/modules/desktop/betterdisplay/scripts.nix
+++ b/modules/desktop/betterdisplay/scripts.nix
@@ -1,0 +1,15 @@
+# Helper scripts that drive BetterDisplay and AeroSpace together.
+#
+# They are packages rather than files linked out of the working tree: the store
+# path is what `betterdisplaycli.nix` and the AeroSpace keybindings point at, so
+# the config no longer depends on the repo being checked out at one particular
+# path.
+{ pkgs }:
+
+{
+  workspace-to-next-monitor = pkgs.writeShellApplication {
+    name = "workspace-to-next-monitor";
+    runtimeInputs = with pkgs; [ aerospace jq ];
+    text = builtins.readFile ./next-monitor-of-workspace.sh;
+  };
+}

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -4,6 +4,7 @@
     ./aerospace/aerospace.nix
     ./betterdisplay
     ./dock.nix
+    ./raycast
     ./sketchybar/sketchybar.nix
   ];
 }

--- a/modules/desktop/raycast/default.nix
+++ b/modules/desktop/raycast/default.nix
@@ -1,0 +1,47 @@
+# Raycast script commands.
+#
+# Raycast finds script commands by scanning a directory you nominate once in its
+# settings ("Script Commands" -> "Add Script Directory") for executable `.sh`
+# files carrying `@raycast.*` header comments. That rules out shipping them as
+# packages on PATH — the filename and the extension are part of the contract —
+# so they are rendered into a stable path in the home directory instead, and
+# `nix run .#build-switch` keeps them current.
+#
+# Point Raycast at ~/.config/raycast/scripts. `quicklinks.json` next to the
+# sources still has to be imported by hand; Raycast has no on-disk format for
+# quicklinks.
+{ config, lib, pkgs, ... }:
+
+let
+  user = config.mine.user.name;
+  scriptDir = ../../config/raycast/scripts;
+
+  # Raycast launches these from the GUI session, whose PATH is not the shell's,
+  # so the tools they need are pinned to the store here rather than looked up.
+  # `/usr/local/bin` is on the end for `betterdisplaycli`, which the ultra-wide
+  # scripts drive and which `modules/desktop/betterdisplay` installs there.
+  runtimePath = lib.makeBinPath (with pkgs; [ aerospace jq coreutils gnused ]);
+
+  # The sources are stored without a shebang, as the repo does elsewhere for
+  # scripts that only ever run with a generated preamble.
+  render = name: ''
+    #!${pkgs.bash}/bin/bash
+    export PATH="${runtimePath}:/usr/local/bin:$PATH"
+    ${builtins.readFile (scriptDir + "/${name}")}'';
+
+  # Everything in the directory except the upstream template, which is a
+  # starting point to copy rather than a command to install.
+  names = lib.filter
+    (name: lib.hasSuffix ".sh" name && !(lib.hasInfix ".template." name))
+    (lib.attrNames (builtins.readDir scriptDir));
+in
+{
+  config = lib.mkIf config.mine.desktop.raycast.enable {
+    home-manager.users.${user}.home.file = lib.listToAttrs (map
+      (name: lib.nameValuePair ".config/raycast/scripts/${name}" {
+        executable = true;
+        text = render name;
+      })
+      names);
+  };
+}

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -60,9 +60,10 @@
     '';
 
     betterdisplay.enable = lib.mkEnableOption ''
-      the BetterDisplay helper scripts: a `betterdisplaycli` shim and
-      `workspace-to-next-monitor`, both installed into /usr/local/bin by an
-      activation script. Needs the `betterdisplay` cask, which is currently
+      the BetterDisplay helper scripts: a `betterdisplaycli` shim, and
+      `workspace-to-next-monitor`, which is a package on PATH and also shimmed
+      into /usr/local/bin because the .aerospace.toml keybindings call it by
+      absolute path (#21). Needs the `betterdisplay` cask, which is currently
       listed in modules/homebrew.nix (#9 moves that here)
     '';
 
@@ -71,6 +72,14 @@
       populated from `local.dock.entries` or stripped entirely, depending on
       `local.dock.enable`. When off, this config does not touch the Dock at all,
       which is what you want on a machine whose Dock someone else arranged
+    '';
+
+    raycast.enable = lib.mkEnableOption ''
+      the Raycast script commands from modules/config/raycast, rendered into
+      ~/.config/raycast/scripts. Raycast still has to be pointed at that
+      directory by hand, once — see that directory's readme. The ultra-wide
+      scripts also drive `betterdisplaycli`, so they want
+      `mine.desktop.betterdisplay.enable` as well (#21)
     '';
   };
 

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -20,7 +20,10 @@
   imports = [
     {
       config = lib.mkIf config.mine.services."screen-lock-monitor".enable
-        (import ./screen-lock-monitor { inherit pkgs; });
+        (import ./screen-lock-monitor {
+          inherit pkgs;
+          user = config.mine.user.name;
+        });
     }
   ];
 }

--- a/modules/services/screen-lock-monitor/default.nix
+++ b/modules/services/screen-lock-monitor/default.nix
@@ -1,4 +1,6 @@
-{ pkgs, ... }:
+# Called by ../default.nix as a plain function, not evaluated as a module, so
+# the account name is passed in rather than read off `config`.
+{ pkgs, user }:
 
 let
   screenLockMonitor = pkgs.stdenv.mkDerivation {
@@ -24,7 +26,9 @@ in
 
   launchd.user.agents.screen-lock-monitor = {
     serviceConfig = {
-      Label = "com.david.screen-lock-monitor";
+      # Reverse-DNS label keyed on the account that owns the agent, so a fork
+      # does not end up running a job announced as david's.
+      Label = "com.${user}.screen-lock-monitor";
       ProgramArguments = [ "${screenLockMonitor}/bin/screen-lock-monitor" ];
       RunAtLoad = true;
       KeepAlive = true;


### PR DESCRIPTION
Closes #4. Rebased onto `main` after #18 and #19.

Several modules only worked because the repo happened to be checked out at `/Users/david/.config/nixos-config` and the account happened to be `david`.

### betterdisplay

`next-monitor-of-workspace.sh` is now a `pkgs.writeShellApplication` with `aerospace` and `jq` as `runtimeInputs`, installed as a package instead of `ln -f`'d out of the working tree. shellcheck runs on it at build time now, which is how the unquoted `$1` got noticed.

The `/usr/local/bin/workspace-to-next-monitor` shim stays, but points at the store path. AeroSpace's `exec-and-forget` inherits the GUI session's PATH, which is not guaranteed to include `/run/current-system/sw/bin`, so the `.aerospace.toml` keybindings need an absolute path to stay working. That coupling is #21.

### raycast

`modules/config/raycast/` was tracked but imported by no nix file. Wired up rather than deleted, per your call. `modules/desktop/raycast` renders each script command into `~/.config/raycast/scripts` with a shebang and a store-pinned PATH prepended, so the sources are shebang-less and call `aerospace` / `betterdisplaycli` by bare name.

They are rendered into the home rather than shipped as packages on PATH because Raycast identifies script commands by filename, `.sh` extension and `@raycast.*` header comments — none of which survive `writeShellApplication`. Adding the script directory in Raycast's settings and importing `quicklinks.json` are still one-time manual steps; the readme now says so instead of "everything here needs to be imported manually".

`script-command.template.sh` is skipped — it is a thing to copy, not a command to install.

### screen-lock-monitor

Launchd label comes from `mine.user.name`. Passed in as a function argument rather than read off `config`, because after #18 `modules/services/default.nix` imports this as a plain function specifically to keep the `src = ./.` hash out of the module system — turning it back into a module would undo that.

### emacs

`config.org` expanded home-relative entries in `PATH` / `exec-path` at startup instead of naming the account. This file is currently dead — `init.el` tangles it from `~/.local/share/src/nixos-config/modules/shared/config/emacs/config.org`, which does not exist. Fixed anyway since it was in the grep, but that staleness is unaddressed.

### Rebase notes

#18 landed `mkEnableOption` gating on the same files, so this now follows that shape:

- New `mine.desktop.raycast.enable`, off by default like its neighbours. On for `David-M3-Pro`, off for `example` — so CI exercises both branches of the gate.
- `betterdisplaycli.nix` keeps its `lib.mkIf config.mine.desktop.betterdisplay.enable` and the package goes inside it.
- The `betterdisplay.enable` description in `options.nix` is updated: `workspace-to-next-monitor` is a package on PATH now as well as a shim.
- Two host comments called out this issue as outstanding — `example`'s note that betterdisplay "still hardcodes a /Users/david path (#4)", and its note that the launchd agent is "labelled com.david.*". Both corrected.

### Verification

```
nix eval .#darwinConfigurations.David-M3-Pro.config.system.build.toplevel.drvPath   # ok
nix eval .#darwinConfigurations.example.config.system.build.toplevel.drvPath        # ok
```

On `David-M3-Pro`: label is `com.david.screen-lock-monitor`, the activation shim points into the store, and the rendered raycast scripts carry a store PATH and no `/Users/david`. On `example`: label evaluates to `com.changeme.screen-lock-monitor`, no raycast files, no launchd agent.

The one remaining `/Users/david` in the tree is `last_opened_file_path` IDE state under `modules/config/datagrip/`, left alone because #7 rebuilds that feature properly.