### PR TITLE
refactor: make inter-module dependencies real instead of implicit

### DIFF
--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -29,16 +29,14 @@
     # modules/desktop/sketchybar/sketchybar.nix; same end state, expressed here.
     sketchybar.enable = false;
 
-    # The /usr/local/bin shims for the BetterDisplay cask, plus
-    # workspace-to-next-monitor, which aerospace binds to.
+    # `betterdisplaycli`, which the raycast scripts below are built out of.
     betterdisplay.enable = true;
 
     # On: this config manages the Dock. Which today means stripping it, since
     # `local.dock.enable` is false and the entries list is empty.
     dock.enable = true;
 
-    # The ultra-wide script commands. They drive betterdisplaycli, so this
-    # wants betterdisplay.enable above (#21).
+    # The ultra-wide script commands. These assert betterdisplay.enable above.
     raycast.enable = true;
   };
 

--- a/hosts/example/default.nix
+++ b/hosts/example/default.nix
@@ -32,8 +32,8 @@
     # Off. A status bar is a taste, not a default.
     sketchybar.enable = false;
 
-    # Off. The activation script writes to /usr/local/bin, and none of it means
-    # anything without the BetterDisplay cask actually installed.
+    # Off. `betterdisplaycli` wraps a binary inside the BetterDisplay app
+    # bundle, so it means nothing without the cask actually installed.
     betterdisplay.enable = false;
 
     # Off. With `local.dock.enable` false this would strip the Dock bare on
@@ -41,8 +41,10 @@
     # surprise.
     dock.enable = false;
 
-    # Off. The scripts here are for one specific ultra-wide monitor, and
-    # wiring them up needs a manual step in Raycast's settings anyway.
+    # Off. The scripts here are for one specific ultra-wide monitor, and wiring
+    # them up needs a manual step in Raycast's settings anyway. It would also
+    # fail the assertion in modules/desktop/raycast with betterdisplay off,
+    # which is the point of that assertion.
     raycast.enable = false;
   };
 

--- a/modules/desktop/aerospace/.aerospace.toml
+++ b/modules/desktop/aerospace/.aerospace.toml
@@ -142,6 +142,11 @@ ctrl-0 = 'workspace 10'
 # ctrl-y = 'workspace Y'
 # ctrl-z = 'workspace Z'
 
+# `workspace-to-next-monitor` below is written as a bare name on purpose:
+# aerospace.nix substitutes the store path of the package in before handing
+# these bindings to nix-darwin. `exec-and-forget` does not run through a login
+# shell, so a bare name would not otherwise resolve (#21).
+#
 # See: https://nikitabobko.github.io/AeroSpace/commands#move-node-to-workspace
 ctrl-shift-1 = 'move-node-to-workspace 1'
 ctrl-shift-2 = 'move-node-to-workspace 2'
@@ -153,16 +158,16 @@ ctrl-shift-7 = 'move-node-to-workspace 7'
 ctrl-shift-8 = 'move-node-to-workspace 8'
 ctrl-shift-9 = 'move-node-to-workspace 9'
 ctrl-shift-0 = 'move-node-to-workspace 10'
-ctrl-shift-alt-1 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 1'
-ctrl-shift-alt-2 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 2'
-ctrl-shift-alt-3 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 3'
-ctrl-shift-alt-4 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 4'
-ctrl-shift-alt-5 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 5'
-ctrl-shift-alt-6 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 6'
-ctrl-shift-alt-7 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 7'
-ctrl-shift-alt-8 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 8'
-ctrl-shift-alt-9 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 9'
-ctrl-shift-alt-0 = 'exec-and-forget /usr/local/bin/workspace-to-next-monitor 10'
+ctrl-shift-alt-1 = 'exec-and-forget workspace-to-next-monitor 1'
+ctrl-shift-alt-2 = 'exec-and-forget workspace-to-next-monitor 2'
+ctrl-shift-alt-3 = 'exec-and-forget workspace-to-next-monitor 3'
+ctrl-shift-alt-4 = 'exec-and-forget workspace-to-next-monitor 4'
+ctrl-shift-alt-5 = 'exec-and-forget workspace-to-next-monitor 5'
+ctrl-shift-alt-6 = 'exec-and-forget workspace-to-next-monitor 6'
+ctrl-shift-alt-7 = 'exec-and-forget workspace-to-next-monitor 7'
+ctrl-shift-alt-8 = 'exec-and-forget workspace-to-next-monitor 8'
+ctrl-shift-alt-9 = 'exec-and-forget workspace-to-next-monitor 9'
+ctrl-shift-alt-0 = 'exec-and-forget workspace-to-next-monitor 10'
 # ctrl-shift-a = 'move-node-to-workspace A'
 # ctrl-shift-b = 'move-node-to-workspace B'
 # ctrl-shift-c = 'move-node-to-workspace C'

--- a/modules/desktop/aerospace/aerospace.nix
+++ b/modules/desktop/aerospace/aerospace.nix
@@ -1,10 +1,33 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 
+let
+  scripts = import ./scripts.nix { inherit pkgs; };
+
+  raw = lib.importTOML ./.aerospace.toml;
+
+  # The .aerospace.toml is kept editable by hand — it is upstream's example file
+  # with edits, and staying diffable against it is worth more than expressing
+  # ten keybindings in nix. So it names the script bare and the store path is
+  # substituted in here, which is what lets the /usr/local/bin shim go away
+  # (#21): `exec-and-forget` inherits AeroSpace's PATH, not a login shell's, so
+  # the binding has to carry an absolute path one way or another. Now it is an
+  # absolute path into the store, which a rollback takes with it.
+  resolve = lib.replaceStrings
+    [ "exec-and-forget workspace-to-next-monitor" ]
+    [ "exec-and-forget ${lib.getExe scripts.workspace-to-next-monitor}" ];
+
+  settings = lib.recursiveUpdate raw {
+    mode.main.binding = lib.mapAttrs (_: resolve) raw.mode.main.binding;
+  };
+in
 {
   config = lib.mkIf config.mine.desktop.aerospace.enable {
+    # Also on PATH, so the same thing can be run from a terminal.
+    environment.systemPackages = [ scripts.workspace-to-next-monitor ];
+
     services.aerospace = {
+      inherit settings;
       enable = true;
-      settings = lib.importTOML ./.aerospace.toml;
     };
   };
 }

--- a/modules/desktop/aerospace/next-monitor-of-workspace.sh
+++ b/modules/desktop/aerospace/next-monitor-of-workspace.sh
@@ -7,6 +7,11 @@
 #
 # Sends a workspace to the "other" monitor of the pair: Left <-> Right, and the
 # ultra-wide back to Left. Bound to ctrl-shift-alt-<N> in .aerospace.toml.
+#
+# It lives with aerospace rather than with betterdisplay because `aerospace` is
+# the only thing it runs. The monitor names it matches on are BetterDisplay's
+# virtual screens, but that is a fact about how the displays are arranged at
+# runtime, not a dependency on the betterdisplay module (#21).
 
 result=$(aerospace list-workspaces --all --json --format "%{workspace}%{monitor-name}" | jq -r --arg ws "$1" '
   map(select(.workspace == $ws)) | .[0]."monitor-name" as $mon |

--- a/modules/desktop/aerospace/scripts.nix
+++ b/modules/desktop/aerospace/scripts.nix
@@ -1,0 +1,14 @@
+# Scripts that the keybindings in .aerospace.toml call out to.
+#
+# A package set rather than a module: aerospace.nix needs the store path to
+# substitute into the bindings, and `exec-and-forget` runs with AeroSpace's own
+# PATH rather than a login shell's, so a bare name on PATH would not resolve.
+{ pkgs }:
+
+{
+  workspace-to-next-monitor = pkgs.writeShellApplication {
+    name = "workspace-to-next-monitor";
+    runtimeInputs = with pkgs; [ aerospace jq ];
+    text = builtins.readFile ./next-monitor-of-workspace.sh;
+  };
+}

--- a/modules/desktop/betterdisplay/betterdisplaycli.nix
+++ b/modules/desktop/betterdisplay/betterdisplaycli.nix
@@ -5,19 +5,6 @@ let
 in
 {
   config = lib.mkIf config.mine.desktop.betterdisplay.enable {
-    environment.systemPackages = [ scripts.workspace-to-next-monitor ];
-
-    system.activationScripts.extraActivation.text = ''
-      cat > /usr/local/bin/betterdisplaycli << 'EOF'
-      #!/bin/bash
-      exec /Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay "$@"
-      EOF
-      chmod +x /usr/local/bin/betterdisplaycli
-      # AeroSpace's `exec-and-forget` inherits the PATH of the GUI process that
-      # launched it, which is not guaranteed to include the system profile, so
-      # the keybindings in .aerospace.toml go through an absolute path. The shim
-      # points at the store, not at the working tree.
-      ln -sfn ${scripts.workspace-to-next-monitor}/bin/workspace-to-next-monitor /usr/local/bin/workspace-to-next-monitor
-    '';
+    environment.systemPackages = [ scripts.betterdisplaycli ];
   };
 }

--- a/modules/desktop/betterdisplay/scripts.nix
+++ b/modules/desktop/betterdisplay/scripts.nix
@@ -1,15 +1,21 @@
-# Helper scripts that drive BetterDisplay and AeroSpace together.
-#
-# They are packages rather than files linked out of the working tree: the store
-# path is what `betterdisplaycli.nix` and the AeroSpace keybindings point at, so
-# the config no longer depends on the repo being checked out at one particular
-# path.
+# A package set rather than a module, so modules/desktop/raycast can take
+# `betterdisplaycli` as a runtime input without depending on this module's
+# `config` having been evaluated.
 { pkgs }:
 
 {
-  workspace-to-next-monitor = pkgs.writeShellApplication {
-    name = "workspace-to-next-monitor";
-    runtimeInputs = with pkgs; [ aerospace jq ];
-    text = builtins.readFile ./next-monitor-of-workspace.sh;
+  # BetterDisplay ships its CLI inside the .app bundle and puts nothing on PATH.
+  # This used to be a here-doc written into /usr/local/bin by an activation
+  # script; as a package it is in the store, on PATH for both the shell and
+  # anything that lists it as a runtime input, and a rollback takes it with it
+  # (#21).
+  #
+  # The path it execs is outside the store and always will be — it belongs to
+  # the cask, which Homebrew owns. Nothing can be done about that here.
+  betterdisplaycli = pkgs.writeShellApplication {
+    name = "betterdisplaycli";
+    text = ''
+      exec /Applications/BetterDisplay.app/Contents/MacOS/BetterDisplay "$@"
+    '';
   };
 }

--- a/modules/desktop/raycast/default.nix
+++ b/modules/desktop/raycast/default.nix
@@ -16,17 +16,24 @@ let
   user = config.mine.user.name;
   scriptDir = ../../config/raycast/scripts;
 
+  betterdisplay = import ../betterdisplay/scripts.nix { inherit pkgs; };
+
   # Raycast launches these from the GUI session, whose PATH is not the shell's,
   # so the tools they need are pinned to the store here rather than looked up.
-  # `/usr/local/bin` is on the end for `betterdisplaycli`, which the ultra-wide
-  # scripts drive and which `modules/desktop/betterdisplay` installs there.
-  runtimePath = lib.makeBinPath (with pkgs; [ aerospace jq coreutils gnused ]);
+  # `betterdisplaycli` is taken from the betterdisplay package set directly
+  # rather than found on PATH at /usr/local/bin, which is what the assertion
+  # below is really about: the package resolves either way, but it is a wrapper
+  # round an app bundle that is only there if BetterDisplay is installed (#21).
+  runtimePath = lib.makeBinPath (
+    (with pkgs; [ aerospace jq coreutils gnused ])
+    ++ [ betterdisplay.betterdisplaycli ]
+  );
 
   # The sources are stored without a shebang, as the repo does elsewhere for
   # scripts that only ever run with a generated preamble.
   render = name: ''
     #!${pkgs.bash}/bin/bash
-    export PATH="${runtimePath}:/usr/local/bin:$PATH"
+    export PATH="${runtimePath}:$PATH"
     ${builtins.readFile (scriptDir + "/${name}")}'';
 
   # Everything in the directory except the upstream template, which is a
@@ -37,6 +44,23 @@ let
 in
 {
   config = lib.mkIf config.mine.desktop.raycast.enable {
+    # The ultra-wide script commands are 17 calls to `betterdisplaycli` and
+    # nothing else would drive the PiP layout they set up, so raycast without
+    # betterdisplay is a half-configured machine rather than a smaller one. The
+    # flag is the closest thing this repo has to "BetterDisplay is installed";
+    # #9 will move the cask itself under the same flag.
+    assertions = [
+      {
+        assertion = config.mine.desktop.betterdisplay.enable;
+        message = ''
+          mine.desktop.raycast.enable needs mine.desktop.betterdisplay.enable:
+          the ultra-wide script commands drive `betterdisplaycli`, which wraps
+          an app bundle that betterdisplay is what asks for. Either enable
+          betterdisplay too, or turn raycast off.
+        '';
+      }
+    ];
+
     home-manager.users.${user}.home.file = lib.listToAttrs (map
       (name: lib.nameValuePair ".config/raycast/scripts/${name}" {
         executable = true;

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -52,7 +52,8 @@
   options.mine.desktop = {
     aerospace.enable = lib.mkEnableOption ''
       the AeroSpace tiling window manager, configured from
-      modules/desktop/aerospace/.aerospace.toml
+      modules/desktop/aerospace/.aerospace.toml. Also installs
+      `workspace-to-next-monitor`, which the ctrl-shift-alt-<N> bindings call
     '';
 
     sketchybar.enable = lib.mkEnableOption ''
@@ -60,11 +61,10 @@
     '';
 
     betterdisplay.enable = lib.mkEnableOption ''
-      the BetterDisplay helper scripts: a `betterdisplaycli` shim, and
-      `workspace-to-next-monitor`, which is a package on PATH and also shimmed
-      into /usr/local/bin because the .aerospace.toml keybindings call it by
-      absolute path (#21). Needs the `betterdisplay` cask, which is currently
-      listed in modules/homebrew.nix (#9 moves that here)
+      `betterdisplaycli`, a wrapper round the CLI that the BetterDisplay cask
+      hides inside its .app bundle. Needs the cask, which is currently listed
+      unconditionally in modules/homebrew.nix (#9 moves that here). Required by
+      `raycast.enable` below
     '';
 
     dock.enable = lib.mkEnableOption ''
@@ -77,9 +77,9 @@
     raycast.enable = lib.mkEnableOption ''
       the Raycast script commands from modules/config/raycast, rendered into
       ~/.config/raycast/scripts. Raycast still has to be pointed at that
-      directory by hand, once — see that directory's readme. The ultra-wide
-      scripts also drive `betterdisplaycli`, so they want
-      `mine.desktop.betterdisplay.enable` as well (#21)
+      directory by hand, once — see that directory's readme. Requires
+      `betterdisplay.enable` above; the ultra-wide scripts are mostly
+      `betterdisplaycli` calls, and there is an assertion that says so
     '';
   };
 
@@ -88,6 +88,9 @@
     "screen-lock-monitor".enable = lib.mkEnableOption ''
       the screen-lock-monitor launchd agent, a small Swift binary built from
       modules/services/screen-lock-monitor that watches macOS lock/unlock events
+      and flips BetterDisplay's main monitor. Requires
+      `mine.desktop.betterdisplay.enable`; the store path of `betterdisplaycli`
+      is compiled into the binary
     '';
   };
 

--- a/modules/services/default.nix
+++ b/modules/services/default.nix
@@ -3,6 +3,8 @@
 #
 # screen-lock-monitor is gated from out here rather than from inside its own
 # file, which is the one exception to that shape and is deliberate. Its
+# dependency on betterdisplay is passed in from here too, as a store path
+# rather than the /usr/local/bin convention it used to assume (#21). Its
 # derivation uses `src = ./.`, so every file in
 # modules/services/screen-lock-monitor is a build input — the .nix file
 # included. Putting `lib.mkIf` in there would change the source hash and force a
@@ -19,10 +21,28 @@
 {
   imports = [
     {
+      # `//` rather than a second module in this list: the assertion adds no
+      # `environment.systemPackages`, so merging it into the same attrset keeps
+      # the import list one entry long and the ordering above intact.
       config = lib.mkIf config.mine.services."screen-lock-monitor".enable
-        (import ./screen-lock-monitor {
-          inherit pkgs;
+        ((import ./screen-lock-monitor {
+          inherit lib pkgs;
           user = config.mine.user.name;
+          betterdisplaycli =
+            (import ../desktop/betterdisplay/scripts.nix { inherit pkgs; })
+            .betterdisplaycli;
+        }) // {
+          assertions = [
+            {
+              assertion = config.mine.desktop.betterdisplay.enable;
+              message = ''
+                mine.services."screen-lock-monitor".enable needs
+                mine.desktop.betterdisplay.enable: the agent exists to flip
+                BetterDisplay's main monitor on lock and unlock, and does
+                nothing useful without it.
+              '';
+            }
+          ];
         });
     }
   ];

--- a/modules/services/screen-lock-monitor/default.nix
+++ b/modules/services/screen-lock-monitor/default.nix
@@ -1,6 +1,7 @@
 # Called by ../default.nix as a plain function, not evaluated as a module, so
-# the account name is passed in rather than read off `config`.
-{ pkgs, user }:
+# the account name and the betterdisplaycli path are passed in rather than read
+# off `config`.
+{ lib, pkgs, user, betterdisplaycli }:
 
 let
   screenLockMonitor = pkgs.stdenv.mkDerivation {
@@ -10,7 +11,16 @@ let
 
     nativeBuildInputs = [ pkgs.swift ];
 
+    # The Swift source drives BetterDisplay, and used to reach it through
+    # /usr/local/bin/betterdisplaycli — a path another module's activation
+    # script happened to write. Baking the store path in at build time makes
+    # that dependency an argument to this derivation instead of a convention
+    # nothing enforced (#21). --replace-fail so a renamed placeholder is a build
+    # error rather than a binary that silently points at nothing.
     buildPhase = ''
+      substituteInPlace screen-lock-monitor.swift \
+        --replace-fail "@betterdisplaycli@" "${lib.getExe betterdisplaycli}"
+
       swiftc -O -o screen-lock-monitor screen-lock-monitor.swift \
         -framework Cocoa -framework Foundation
     '';

--- a/modules/services/screen-lock-monitor/screen-lock-monitor.swift
+++ b/modules/services/screen-lock-monitor/screen-lock-monitor.swift
@@ -1,7 +1,12 @@
 import Cocoa
 import Foundation
 
-let betterdisplaycli = "/usr/local/bin/betterdisplaycli"
+// Replaced with the store path of the `betterdisplaycli` package at build time
+// by default.nix; the placeholder is not a path and this will not compile into
+// anything runnable without that substitution (#21). It used to be a literal
+// /usr/local/bin path written by another module's activation script, with
+// nothing anywhere saying so.
+let betterdisplaycli = "@betterdisplaycli@"
 let mainMonitorName = "Left"
 let physicalMonitorName = "Odyssey G93SC"
 
@@ -11,7 +16,17 @@ func run(_ arguments: [String]) -> String {
     process.executableURL = URL(fileURLWithPath: betterdisplaycli)
     process.arguments = arguments
     process.standardOutput = pipe
-    try? process.run()
+    do {
+        try process.run()
+    } catch {
+        // This was `try?`, which meant a missing or broken betterdisplaycli
+        // left the agent running and quietly doing nothing at every lock and
+        // unlock. Say so in the log instead.
+        FileHandle.standardError.write(
+            "screen-lock-monitor: could not run \(betterdisplaycli): \(error)\n"
+                .data(using: .utf8)!)
+        return ""
+    }
     process.waitUntilExit()
     let data = pipe.fileHandleForReading.readDataToEndOfFile()
     return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""


### PR DESCRIPTION
Closes #21.

Modules reached each other through `/usr/local/bin`: betterdisplay's activation script wrote shims there, and aerospace, raycast and screen-lock-monitor all assumed they would find them. Nothing declared that, nothing checked it, and every failure mode was silent. `/usr/local/bin` is also outside the store, so a rollback left the newer generation's shims sitting there.

**There is no `/usr/local/bin` left in the config.** Taking the issue's three questions in order:

### "Do modules get enable flags so one can read another's?"

Already answered by #18 — they have them. What was missing was anything using them, which is the assertions below.

### "Should the aerospace keybindings be generated from nix?"

Substituted, not generated. `workspace-to-next-monitor` turned out never to be a betterdisplay script at all: it runs `aerospace` and nothing else. The monitor names it matches on are BetterDisplay's virtual screens, but that is a runtime fact about how the displays are arranged, not a module edge. So it moves to `modules/desktop/aerospace/`, and half of this issue dissolves rather than needing machinery to declare it.

`aerospace.nix` then substitutes the package's store path into the `ctrl-shift-alt-<N>` bindings. The `.aerospace.toml` stays hand-editable and diffable against upstream's example file — it names the script bare, and nix rewrites it. `exec-and-forget` inherits AeroSpace's PATH rather than a login shell's, so the binding needs an absolute path one way or another; now it is one the store owns and a rollback takes with it.

### "Is /usr/local/bin worth keeping as a handoff point?"

No. `betterdisplaycli` was a here-doc written at activation; it is a `writeShellApplication` now, exported from a package set any module can import. raycast takes it as a runtime input instead of hoping to find it on PATH.

The path it execs (`/Applications/BetterDisplay.app/...`) is still outside the store and always will be — that belongs to the cask, which Homebrew owns.

### One thing the issue did not list

`screen-lock-monitor.swift` was a third consumer of the shim, hardcoding `/usr/local/bin/betterdisplaycli` and running it with `try?`. Deleting the shim would have left the agent running and silently doing nothing at every lock and unlock — the exact failure mode the issue describes, and one I would have introduced.

The store path is substituted in at build time through a placeholder and `--replace-fail`, so the dependency is now an edge in the nix closure:

```
$ nix-store -q --references .../screen-lock-monitor-1.0.0 | grep betterdisplaycli
/nix/store/c428sbxxjhbyqrma3wbkpvlm5552qggv-betterdisplaycli
```

The `try?` is now a `do`/`catch` that writes to stderr, which lands in the agent's log.

### Assertions

Two dependencies are real and stay declared: raycast needs betterdisplay (its ultra-wide scripts are 17 `betterdisplaycli` calls), and so does screen-lock-monitor. Both assert in the enabled branch only, so `hosts/example` still evaluates with everything off.

Verified they actually fire, rather than just existing:

```
$ nix eval ... example.extendModules { mine.desktop.raycast.enable = mkForce true; }
error: Failed assertions:
- mine.desktop.raycast.enable needs mine.desktop.betterdisplay.enable: ...

$ nix eval ... example.extendModules { mine.services."screen-lock-monitor".enable = mkForce true; }
error: Failed assertions:
- mine.services."screen-lock-monitor".enable needs mine.desktop.betterdisplay.enable: ...
```

### Verification

Both hosts evaluate. The Swift binary was compiled for real, not dry-run, since its source changed. All 10 aerospace bindings carry a store path, 0 remain bare, 0 mention `/usr/local/bin`; untouched bindings like `ctrl-shift-1` are unchanged. `extraActivation` no longer writes to `/usr/local/bin` at all.

Option descriptions and the host comments that described the old shim behaviour are updated alongside.