### PR TITLE
feat: move Homebrew package lists out of modules into hosts (#9)

### DIFF
--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -5,9 +5,9 @@
 #
 # hosts/common/darwin.nix is composed in by flake.nix; this file holds only
 # what is specific to this machine: the identity that used to be duplicated as
-# `let user = "david"` across five module files (#2), and the enable flags that
-# used to be hardcoded inside the modules themselves (#3). The package lists
-# (#9) move here as that issue lands.
+# `let user = "david"` across five module files (#2), the enable flags that used
+# to be hardcoded inside the modules themselves (#3), and the Homebrew lists
+# that used to sit in modules/homebrew.nix (#9).
 { ... }:
 
 {
@@ -70,6 +70,63 @@
           url = "jdbc:postgresql://localhost:5432/postgres";
         };
       };
+  };
+
+  # Homebrew (#9). These used to be a flat list inside modules/homebrew.nix,
+  # which meant a fork of this repo got Steam, NordVPN and Autodesk Fusion
+  # whether it wanted them or not. Nothing here is a dependency of anything in
+  # modules/ — the casks that are (betterdisplay, raycast, datagrip) are
+  # declared by the modules that need them and follow the flags above.
+  mine.homebrew = {
+    brews = [
+      "git-secret"
+      "deno"
+      "fga"
+      "scrcpy"
+      "rust"
+      "httpie"
+      # Salesforce CLI. Was also listed as a cask, where the same tool ships
+      # under the token `salesforce-cli` and is disabled upstream since
+      # 2026-09-01 for failing Gatekeeper; the formula is the one that works.
+      "sf"
+    ];
+
+    casks = [
+      # Development
+      "docker-desktop"
+      "visual-studio-code"
+      "zed"
+      "openlens"
+      "warp"
+
+      # Communication
+      "discord"
+      "signal"
+
+      # Entertainment
+      "vlc"
+      "spotify"
+      "jellyfin-media-player"
+      "steam"
+      "obs"
+
+      # Browsers
+      "sigmaos"
+
+      # Networking
+      "zerotier-one"
+      "pritunl"
+      "nordvpn"
+
+      # 3D printing and CAD
+      "autodesk-fusion"
+      "orcaslicer"
+
+      # Screens and peripherals
+      "deskflow"
+      "parsec"
+      "camo-studio"
+    ];
   };
 
   mine.services."screen-lock-monitor".enable = true;

--- a/hosts/example/default.nix
+++ b/hosts/example/default.nix
@@ -10,8 +10,9 @@
 # `nix flake show`, `nix flake check` and CI all need it to — while being
 # visibly wrong to anyone who actually tries to build it.
 #
-# It is not derived from hosts/David-M3-Pro and is meant to diverge from it as
-# the package lists (#9) land.
+# It is not derived from hosts/David-M3-Pro and diverges from it deliberately:
+# the flags below are what a generic fork should get, and the Homebrew lists
+# (#9) are a short seed rather than one person's applications.
 { ... }:
 
 {
@@ -46,6 +47,28 @@
     # fail the assertion in modules/desktop/raycast with betterdisplay off,
     # which is the point of that assertion.
     raycast.enable = false;
+  };
+
+  # Homebrew (#9). This is the seed a fork copies and edits, so it is a short
+  # generic list rather than a copy of hosts/David-M3-Pro — Steam, NordVPN and
+  # Autodesk Fusion are exactly the sort of thing that should not arrive with a
+  # config someone else wrote. Add what you actually use; `brew search` takes
+  # the same names.
+  #
+  # Casks a module cannot work without are not listed here and never need to be:
+  # `mine.desktop.betterdisplay.enable` pulls the betterdisplay cask itself, and
+  # `mine.desktop.raycast.enable` pulls raycast.
+  mine.homebrew = {
+    # Formulae: command-line tools Homebrew has and nixpkgs does not, or does
+    # not have working on darwin. Everything else goes in
+    # modules/home-packages.nix, which is nix and therefore reproducible.
+    brews = [ ];
+
+    # Casks: GUI applications, which macOS mostly does not have in nixpkgs.
+    casks = [
+      "visual-studio-code"
+      "vlc"
+    ];
   };
 
   # Off. A launchd agent watching lock events is not a generic want. The label

--- a/modules/README.md
+++ b/modules/README.md
@@ -17,7 +17,8 @@ Everything here runs on macOS (aarch64-darwin). There is no `shared` /
 │                          # plus datagrip/, which is a nix-darwin module (it owns
 │                          # both the cask and the IDE's datasource file)
 ├── files.nix              # Non-Nix, static configuration files (now immutable!)
-├── homebrew.nix           # Homebrew policy, packages & casks
+├── homebrew.nix           # Homebrew policy; the lists come from mine.homebrew.*
+│                          # in hosts/<hostname>
 ├── packages.nix           # System packages (environment.systemPackages)
 └── home-packages.nix      # User packages (home-manager), packages.nix plus extras
 ```

--- a/modules/desktop/betterdisplay/default.nix
+++ b/modules/desktop/betterdisplay/default.nix
@@ -1,6 +1,15 @@
-{ ... }:
+{ config, lib, ... }:
 {
   imports = [
     ./betterdisplaycli.nix
   ];
+
+  # The cask, not as a preference but as this module's implementation: the
+  # wrapper in betterdisplaycli.nix runs a binary inside
+  # /Applications/BetterDisplay.app, so `mine.desktop.betterdisplay.enable`
+  # without the cask is a module that cannot work. It used to sit unconditionally
+  # in modules/homebrew.nix (#9).
+  config = lib.mkIf config.mine.desktop.betterdisplay.enable {
+    homebrew.casks = [ "betterdisplay" ];
+  };
 }

--- a/modules/desktop/raycast/default.nix
+++ b/modules/desktop/raycast/default.nix
@@ -44,11 +44,15 @@ let
 in
 {
   config = lib.mkIf config.mine.desktop.raycast.enable {
+    # The app itself, for the same reason modules/desktop/betterdisplay declares
+    # its cask: script commands rendered into ~/.config/raycast/scripts do
+    # nothing at all without the thing that scans that directory (#9).
+    homebrew.casks = [ "raycast" ];
+
     # The ultra-wide script commands are 17 calls to `betterdisplaycli` and
     # nothing else would drive the PiP layout they set up, so raycast without
-    # betterdisplay is a half-configured machine rather than a smaller one. The
-    # flag is the closest thing this repo has to "BetterDisplay is installed";
-    # #9 will move the cask itself under the same flag.
+    # betterdisplay is a half-configured machine rather than a smaller one.
+    # betterdisplay is what pulls the cask that `betterdisplaycli` wraps.
     assertions = [
       {
         assertion = config.mine.desktop.betterdisplay.enable;

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -1,4 +1,16 @@
-_:
+# Homebrew: policy and wiring, and no package names.
+#
+# What lives here is the part every machine shares — Homebrew is on, and how it
+# behaves during an activation. *What* gets installed is a property of the
+# person or the machine, so it comes from `mine.homebrew.*` (declared in
+# modules/options.nix) and is set in hosts/<hostname> (#9).
+#
+# Modules add to these lists too, for the one case that is not taste: a module
+# that shells out to an app bundle needs that cask the way `services.foo.enable`
+# needs `pkgs.foo` upstream. `homebrew.casks` is a list option, so those
+# contributions merge with whatever the host asked for; see
+# modules/desktop/betterdisplay for the shape.
+{ config, ... }:
 {
   homebrew = {
     enable = true;
@@ -19,58 +31,6 @@ _:
       cleanup = "none";
     };
 
-    brews = [
-      "git-secret"
-      "deno"
-      "fga"
-      "scrcpy"
-      "rust"
-      "httpie"
-      "sf"
-    ];
-    casks = [
-      # Development Tools
-      "docker-desktop"
-      "visual-studio-code"
-      # datagrip is added by modules/programs/datagrip when
-      # `mine.programs.datagrip.enable` is on (#7), the shape #9 gives the rest.
-      "openlens"
-      "deskflow"
-      "signal"
-      "betterdisplay"
-      # Communication Tools
-      "discord"
-
-      # Entertainment Tools
-      "vlc"
-      "spotify"
-      "jellyfin-media-player"
-      "steam"
-      "obs"
-
-      # Editors
-      "zed"
-
-      # Terminal
-      "warp"
-      "sf"
-      "raycast"
-
-      # Browsers
-      "sigmaos"
-
-      # Networking
-      "zerotier-one"
-      "pritunl"
-
-      # 3D
-      "autodesk-fusion"
-      "orcaslicer"
-
-      "parsec"
-      "nordvpn"
-
-      "camo-studio"
-    ];
+    inherit (config.mine.homebrew) brews casks taps;
   };
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -61,9 +61,8 @@
     '';
 
     betterdisplay.enable = lib.mkEnableOption ''
-      `betterdisplaycli`, a wrapper round the CLI that the BetterDisplay cask
-      hides inside its .app bundle. Needs the cask, which is currently listed
-      unconditionally in modules/homebrew.nix (#9 moves that here). Required by
+      BetterDisplay: installs the cask and `betterdisplaycli`, a wrapper round
+      the CLI that the cask hides inside its .app bundle. Required by
       `raycast.enable` below
     '';
 
@@ -75,11 +74,12 @@
     '';
 
     raycast.enable = lib.mkEnableOption ''
-      the Raycast script commands from modules/config/raycast, rendered into
-      ~/.config/raycast/scripts. Raycast still has to be pointed at that
-      directory by hand, once — see that directory's readme. Requires
-      `betterdisplay.enable` above; the ultra-wide scripts are mostly
-      `betterdisplaycli` calls, and there is an assertion that says so
+      Raycast: installs the cask and the script commands from
+      modules/config/raycast, rendered into ~/.config/raycast/scripts. Raycast
+      still has to be pointed at that directory by hand, once — see that
+      directory's readme. Requires `betterdisplay.enable` above; the ultra-wide
+      scripts are mostly `betterdisplaycli` calls, and there is an assertion
+      that says so
     '';
   };
 
@@ -93,6 +93,54 @@
       connections are in every project on every machine. Off means this config
       does not install DataGrip and never touches its files
     '';
+  };
+
+  # What to install from Homebrew. This is the "wanted by a person" half of the
+  # split in #9: modules/homebrew.nix keeps the activation policy and names no
+  # packages at all, and every package name that is pure preference is set in
+  # hosts/<hostname>.
+  #
+  # The other half — a cask a module cannot work without, like BetterDisplay for
+  # `mine.desktop.betterdisplay` — is declared by that module against
+  # `homebrew.casks` directly, the way `services.foo.enable` pulls `pkgs.foo`
+  # upstream. Those merge with what is set here; nobody has to list them.
+  options.mine.homebrew = {
+    brews = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "httpie" ];
+      description = ''
+        Homebrew formulae to install: command-line tools that nixpkgs either
+        does not have or does not have working on darwin. Anything nixpkgs
+        packages properly belongs in modules/home-packages.nix instead.
+      '';
+    };
+
+    casks = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "vlc" ];
+      description = ''
+        Homebrew casks to install: GUI applications, which on macOS is very
+        nearly all of them. A cask a module needs to function is declared by
+        that module rather than listed here.
+      '';
+    };
+
+    taps = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "example/tap" ];
+      description = ''
+        Extra taps to make available to `brew bundle`.
+
+        Note that flake.nix sets `nix-homebrew.mutableTaps = false`, so taps are
+        pinned as flake inputs and cloned from the store; a tap named here also
+        has to be added to `nix-homebrew.taps` there, or the activation will try
+        to fetch it and fail. The option exists so a fork that wants mutable
+        taps has the seam already in place.
+      '';
+    };
   };
 
   options.mine.services = {

--- a/modules/programs/datagrip/default.nix
+++ b/modules/programs/datagrip/default.nix
@@ -291,8 +291,8 @@ in
       cfg.datasources;
 
     # "I want DataGrip" is one switch: the app and its connections. The cask
-    # used to sit unconditionally in modules/homebrew.nix; this is the shape #9
-    # gives the rest of them.
+    # used to sit unconditionally in modules/homebrew.nix; #9 gave the rest of
+    # them the same shape — either a module owns a cask, or a host lists it.
     homebrew.casks = [ "datagrip" ];
 
     home-manager.users.${user} = { lib, ... }: {


### PR DESCRIPTION
Closes #9.

`modules/homebrew.nix` held a flat list of 25 casks and 7 brews — Steam, Spotify, NordVPN, Autodesk Fusion — in a file that is meant to be shared mechanism. A fork got one person's applications whether it wanted them or not.

### The split

Not "core vs personal", but **required by a module** vs **wanted by a person**:

| | Where it lives now |
|---|---|
| `betterdisplay` | `modules/desktop/betterdisplay`, under `mine.desktop.betterdisplay.enable` — `betterdisplaycli` wraps a binary inside the .app bundle, so the cask is the module's implementation, not a taste |
| `raycast` | `modules/desktop/raycast`, under `mine.desktop.raycast.enable` — script commands rendered into `~/.config/raycast/scripts` do nothing without the thing that scans that directory |
| everything else | `hosts/<hostname>`, via new `mine.homebrew.{brews,casks,taps}` |

`homebrew.casks` is a list option, so module contributions merge with the host's and nobody ever lists them by hand. Same shape `services.foo.enable` uses to pull `pkgs.foo` upstream.

`modules/homebrew.nix` is now `enable`, `onActivation` policy, and `inherit (config.mine.homebrew) brews casks taps` — **zero package names**, which is what #10 can grep for.

### hosts/example

Gets a two-cask seed (`visual-studio-code`, `vlc`), not a copy of `hosts/David-M3-Pro`. The issue says the current list goes there, but that host is the thing `#init` (#5) copies and prunes, and arriving with Steam and Autodesk Fusion is the problem this issue is about. Flagging it as a judgment call — say the word and I'll paste the full list in instead.

### Drive-by: the duplicated `sf`

It was in both `brews` and `casks`. The cask token maps to `salesforce-cli`, which Homebrew **disabled on 2026-09-01** for failing the macOS Gatekeeper check; the formula is the same tool and still works. Kept the brew, dropped the cask.

### `taps`

Declared, defaulting to `[]`, with a note in its description: `flake.nix` sets `nix-homebrew.mutableTaps = false`, so a tap named here also has to be pinned as a flake input in `nix-homebrew.taps` or activation will try to fetch it. The option exists so the seam is in place for a fork that wants mutable taps.

### Verification

`nix eval` on the resolved `homebrew.{brews,casks,taps}` for both hosts. `David-M3-Pro` comes out as exactly the previous set minus the dead `sf` cask — 24 casks, 7 brews, `betterdisplay` and `raycast` arriving from their modules. `example` evaluates with no access to the private secrets repo, as CI (#10) needs.
