### PR TITLE
feat: the VPN profile is part of `wm-login` too (#32)

### DIFF
--- a/docs/new-machine.md
+++ b/docs/new-machine.md
@@ -135,8 +135,9 @@ casks the host lists in `mine.homebrew`. Restart the terminal afterwards.
 
 ### 8. Things nix does not do for you
 
-- **App logins.** Docker Desktop, Slack, Spotify, Steam, NordVPN, Pritunl,
-  ZeroTier, Parsec, 1Password: all manual.
+- **App logins.** Docker Desktop, Slack, Spotify, Steam, NordVPN, ZeroTier,
+  Parsec, 1Password: all manual. Pritunl is not in that list — `wm-login`
+  covers it, below.
 - **Raycast.** `modules/config/raycast/` holds the scripts and quicklinks, but
   Raycast has to be pointed at that directory once, and its own settings need
   importing from a Raycast export.
@@ -146,6 +147,12 @@ casks the host lists in `mine.homebrew`. Restart the terminal afterwards.
   browser: run `wm-login` once, and again whenever `withPg` starts failing
   with an SSO error. If the machine had a hand-written `~/.aws/config`, it
   is at `~/.aws/config.before-nix`.
+- **The VPN.** Part of that same `wm-login`: it opens
+  <https://vpn.wemaintain.io/login>, and a profile minted there — the copied
+  link, or the downloaded `.tar`, which it offers by default if it is fresh in
+  `~/Downloads` — is registered with the Pritunl client. Nothing comes from the
+  old Mac; the profile is per machine. Connect it from the Pritunl app once it
+  is added. Already have a profile, the step does nothing.
 - **Monitor names.** The aerospace/betterdisplay scripts address displays by
   the literal names `Left` and `Right`. Rename them in BetterDisplay to match,
   or the ultra-wide Raycast scripts silently do nothing.
@@ -161,8 +168,10 @@ or re-keyed in `nix-secrets`. The old disk simply has to stop existing:
 
 1. Confirm the bundle's backup copy is where you put it in step 1.
 2. Revoke what was per-machine: `~/.ssh/self_deployment` if unused, the GitHub
-   App key under `~/wmtn/` (regenerable from the App's settings), and AWS SSO
-   sessions (`aws sso logout`).
+   App key under `~/wmtn/` (regenerable from the App's settings), AWS SSO
+   sessions (`aws sso logout`), and the old Mac's VPN profile on
+   <https://vpn.wemaintain.io> — the new Mac minted its own, and the old one
+   stays valid until it is deleted there.
 3. Sign out of iCloud, then System Settings > General > Transfer or Reset >
    Erase All Content and Settings. FileVault is on, so this is a cryptographic
    erase.

--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -42,7 +42,8 @@
 
   # Work (#8). One flag: ~/.aws/config with every SSO profile, the RDS CA
   # bundle, `withPg`/`withPgProd`, the DataGrip datasources for the same
-  # databases, gcloud on the data project, and `wm-login`. The profiles,
+  # databases, gcloud on the data project, the Pritunl cask and its VPN
+  # profile (#32), and `wm-login` to do all the browser halves. The profiles,
   # accounts and databases are declared by the module; anything personal on
   # top of them would go here as another `mine.work.wemaintain.*` entry.
   #
@@ -107,9 +108,9 @@
       # Browsers
       "sigmaos"
 
-      # Networking
+      # Networking. Pritunl is not here: it comes with
+      # `mine.work.wemaintain.enable`, which owns the VPN profile too (#32).
       "zerotier-one"
-      "pritunl"
       "nordvpn"
 
       # 3D printing and CAD

--- a/modules/work/wemaintain/default.nix
+++ b/modules/work/wemaintain/default.nix
@@ -1,15 +1,17 @@
 # WeMaintain's cloud environments (#8): AWS SSO profiles, the RDS IAM database
-# helpers, the DataGrip datasources for the same databases, and gcloud.
+# helpers, the DataGrip datasources for the same databases, gcloud, and the
+# Pritunl VPN (#32).
 #
 # Everything a WeMaintain developer needs to reach the cloud from a fresh Mac,
 # behind one flag. Turn on `mine.work.wemaintain.enable`, build-switch, run
 # `wm-login`, and `withPg <anything>` works. No copying ~/.aws from the old
-# machine.
+# machine, and no VPN profile carried over either: it is minted per Mac from
+# the server, and the old machine's is revoked when that machine is retired.
 #
 # This is a nix-darwin module, for the same reason modules/programs/datagrip is:
-# it owns system packages (the CLIs), files in the home directory (~/.aws), and
-# a pre-activation fix-up for a work-installed tool, and all of those belong to
-# the same "I work at WeMaintain" switch.
+# it owns system packages (the CLIs), a cask, files in the home directory
+# (~/.aws), and a pre-activation fix-up for a work-installed tool, and all of
+# those belong to the same "I work at WeMaintain" switch.
 #
 #
 # SINGLE SOURCE OF TRUTH
@@ -113,18 +115,92 @@ let
 
   shellDatabases = lib.filter (db: db.shellFunction != null) (lib.attrValues cfg.databases);
 
-  # The one interactive step nix cannot do: the browser logins. Both SSO tokens
-  # expire (AWS after hours, Google after days), so this is also what to run
+  # The one interactive step nix cannot do: the browser logins. Every one of
+  # them is gated by a consent screen no CLI can drive — AWS and Google because
+  # the SSO tokens expire (after hours and after days respectively), Pritunl
+  # because minting a profile is a WeMaintain SSO login on the server's own web
+  # UI. So this is both the one command to run on a new Mac and what to run
   # when `withPg` starts failing with an SSO error.
+  #
+  # The VPN step is the odd one out in being once-per-machine rather than
+  # per-expiry: it is a no-op the moment a profile exists, so `wm-login` with no
+  # argument stays the right thing to type either way (#32).
   wm-login = pkgs.writeShellApplication {
     name = "wm-login";
-    runtimeInputs = [ pkgs.awscli2 ] ++ lib.optional cfg.gcp.enable pkgs.google-cloud-sdk;
+    runtimeInputs = [ pkgs.awscli2 ]
+      ++ lib.optional cfg.gcp.enable pkgs.google-cloud-sdk
+      ++ lib.optional cfg.vpn.enable pkgs.jq;
     text = ''
       what=''${1:-all}
       case "$what" in
-        aws|gcp|all) ;;
-        *) echo "usage: wm-login [aws|gcp|all]" >&2; exit 2 ;;
+        aws|gcp|${lib.optionalString cfg.vpn.enable "vpn|"}all) ;;
+        *) echo "usage: wm-login [aws|gcp|${lib.optionalString cfg.vpn.enable "vpn|"}all]" >&2; exit 2 ;;
       esac
+
+      ${lib.optionalString cfg.vpn.enable ''
+        # The Pritunl CLI ships inside the cask's app bundle and is deliberately
+        # not on PATH, so it is addressed by its full path.
+        pritunl_client=/Applications/Pritunl.app/Contents/Resources/pritunl-client
+        pritunl_profiles="$HOME/Library/Application Support/pritunl/profiles"
+
+        vpn_profile() {
+          if [ ! -x "$pritunl_client" ]; then
+            echo "    Pritunl is not installed; run 'nix run .#build-switch' first." >&2
+            return 1
+          fi
+
+          # `pritunl-client list` is NOT the check, despite being the obvious
+          # one: on the electron client (1.3.4686) it prints an empty table even
+          # with a profile added and a tunnel up, because it asks the service
+          # rather than reading the app's own store. These files are that store.
+          local existing
+          existing=$(find "$pritunl_profiles" -maxdepth 1 -name '*.conf' 2>/dev/null | sort)
+          if [ -n "$existing" ]; then
+            echo "    a profile is already on this Mac, nothing to mint:"
+            while IFS= read -r conf; do
+              echo "      $(basename "$conf" .conf)  $(jq -r '"\(.organization) / \(.server) / \(.user)"' "$conf")"
+            done <<< "$existing"
+            # Only when asked for the VPN by name: as part of `wm-login all`,
+            # run every time an SSO token expires, this would just be noise.
+            if [ "$what" = vpn ]; then
+              echo "    to replace it, delete it in the Pritunl app and run 'wm-login vpn' again."
+            fi
+            return 0
+          fi
+
+          echo "    log in with WeMaintain SSO, then either copy the profile link"
+          echo "    or download the .tar. Opening the browser."
+          /usr/bin/open ${lib.escapeShellArg cfg.vpn.url} || true
+
+          # Both forms the server hands out are accepted verbatim:
+          # `pritunl-client add [profile_uri|tar_path]`. A .tar that landed in
+          # ~/Downloads while this was running is almost certainly the one, so
+          # it is offered as the default rather than asking for a path to type.
+          local recent="" answer=""
+          recent=$(find "$HOME/Downloads" -maxdepth 1 -name '*.tar' -mmin -30 \
+            -exec stat -f '%m %N' {} + 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+
+          echo
+          if [ -n "$recent" ]; then
+            read -r -p "    profile URI or .tar [$recent]: " answer || answer=""
+            [ -n "$answer" ] || answer="$recent"
+          else
+            read -r -p "    profile URI or .tar: " answer || answer=""
+          fi
+
+          if [ -z "$answer" ]; then
+            echo "    nothing given; run 'wm-login vpn' once you have the profile." >&2
+            return 0
+          fi
+
+          if ! "$pritunl_client" add "$answer"; then
+            echo "    'pritunl-client add' failed. Open Pritunl.app once so its" >&2
+            echo "    service is running, then run 'wm-login vpn' again." >&2
+            return 1
+          fi
+          echo "    added. Connect it from the Pritunl app."
+        }
+      ''}
 
       if [ "$what" = aws ] || [ "$what" = all ]; then
         # The [default] section of ~/.aws/config carries the SSO portal and
@@ -141,6 +217,13 @@ let
           # opposed to the gcloud CLI itself. A separate consent screen.
           gcloud auth application-default login
           gcloud auth application-default set-quota-project ${lib.escapeShellArg cfg.gcp.project}
+        fi
+      ''}
+
+      ${lib.optionalString cfg.vpn.enable ''
+        if [ "$what" = vpn ] || [ "$what" = all ]; then
+          echo "==> Pritunl VPN (${cfg.vpn.url})"
+          vpn_profile
         fi
       ''}
     '';
@@ -318,6 +401,27 @@ in
         description = "Default gcloud project, and the ADC quota project.";
       };
     };
+
+    vpn = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Install the Pritunl cask and give `wm-login` a `vpn` step that mints
+          this Mac's VPN profile from the server below.
+        '';
+      };
+
+      url = lib.mkOption {
+        type = lib.types.str;
+        default = "https://vpn.wemaintain.io/login";
+        description = ''
+          The Pritunl server's login page, opened in the browser by
+          `wm-login vpn`. It is behind WeMaintain SSO, which is why the profile
+          cannot be minted from the CLI.
+        '';
+      };
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -432,6 +536,13 @@ in
       [ wm-login ]
       ++ lib.optional cfg.aws.enable pkgs.awscli2
       ++ lib.optional cfg.gcp.enable pkgs.google-cloud-sdk;
+
+    # The cask, not as a preference but as this module's implementation, the way
+    # modules/desktop/betterdisplay declares its own: `wm-login vpn` runs a
+    # binary inside /Applications/Pritunl.app. It used to be a bare entry in the
+    # host's cask list, where it looked like a personal choice; the VPN it
+    # reaches is a WeMaintain one, so it belongs behind this flag (#32).
+    homebrew.casks = lib.optional cfg.vpn.enable "pritunl";
 
     # DataGrip sees the same databases, if it is enabled at all. The datagrip
     # module ignores this when it is off, so nothing is gated here.


### PR DESCRIPTION
Closes #32.

Pritunl came with the cask and nothing else: a fresh Mac had the app, no profile, and a line on the new-machine checklist telling you to go and get one. The profile itself cannot come from nix or from the old Mac — it is minted per machine on https://vpn.wemaintain.io/login, behind WeMaintain SSO — but everything around it can.

## What changes

**`wm-login` grows a `vpn` step**, included in the default `all`. It opens the login page, then takes either form the server hands out and registers it. A `.tar` that appeared in `~/Downloads` in the last half hour is offered as the prompt default, so the usual path is a return key rather than a path to type.

```
$ wm-login vpn
==> Pritunl VPN (https://vpn.wemaintain.io/login)
    log in with WeMaintain SSO, then either copy the profile link
    or download the .tar. Opening the browser.

    profile URI or .tar [/Users/david/Downloads/everybody_main_david.tar]:
    added. Connect it from the Pritunl app.
```

It is a no-op once a profile exists, which is what keeps it safe inside `all`: re-running `wm-login` for an expired SSO token does not try to mint a second one.

**The cask moves out of the host's list and into the module**, the way `modules/desktop/betterdisplay` declares BetterDisplay: `wm-login vpn` runs a binary inside `/Applications/Pritunl.app`, so the flag that provides the one has to provide the other. In `hosts/David-M3-Pro` it read as a personal choice, which a VPN reachable only by WeMaintain employees is not. New knobs: `mine.work.wemaintain.vpn.enable` (default true) and `.url`.

**Docs follow.** Pritunl leaves the "app logins" list in `docs/new-machine.md` §8, and §9 gains the other half of a per-machine profile: revoking the old Mac's on the server, since nothing else expires it. The same checklist edit is on `feat/init-wizard` (#28) so that branch does not ship the stale line.

## The issue's two open questions, answered on this Mac

- **Which form does the server hand out, and does `add` take it?** Both: `pritunl-client add [profile_uri|tar_path]`. No branching needed.
- **Is `pritunl-client list` the idempotency check?** No, and this is the one place the implementation departs from #32. On the electron client (1.3.4686) `list` prints an empty table even with a profile added *and* a tunnel up, because it asks the service rather than the app's own store:

  ```
  $ pritunl-client list
  +----+------+-------+-----------+------------+----------------+----------------+
  | ID | NAME | STATE | AUTOSTART | ONLINE FOR | SERVER ADDRESS | CLIENT ADDRESS |
  +----+------+-------+-----------+------------+----------------+----------------+
  ```
  ...while `pritunl-openvpn --config /tmp/pritunl/47b95ff7f18390ff` was running. So the check reads `~/Library/Application Support/pritunl/profiles/*.conf` instead, with `jq` pulling org/server/user for the skip message.

## Scope, deliberately

`add` only — no `enable` (autostart) and no `start`. Connecting stays a decision you make in the app.

## Testing

- `nix build` of the `wm-login` derivation passes, so it is shellcheck-clean.
- `wm-login vpn` on David-M3-Pro takes the skip path correctly: `47b95ff7f18390ff  Everybody / Main / david@wemaintain.com`. Inside `wm-login all` the "to replace it" hint is suppressed, so re-logins after SSO expiry stay quiet.
- The evaluated `homebrew.casks` still contains `pritunl` after the move.

**Not yet exercised**, both needing the fresh Mac from #5's live run: the actual `add`, and whether the Pritunl service must be running for it. This Mac already has a profile and mutating live VPN state to test was not worth it. A failing `add` is caught and tells you to open Pritunl.app once and retry.