### PR TITLE
Version the configuration half of `~/.claude` (#36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ docs/research/
 # open, which is how modules/config/datagrip and modules/darwin/home/datagrip
 # ended up in this repo. Datasources are declared in nix now (#7).
 .idea/
+
+# Claude Code agent worktrees, created in whatever repo it is run in.
+.claude/

--- a/docs/two-paths.md
+++ b/docs/two-paths.md
@@ -1,0 +1,103 @@
+# Two ways a module can own a file
+
+Almost every module here generates the file it manages: nix owns the content,
+renders it, and puts it where the program expects. `modules/programs/claude-code`
+does the opposite — the file lives in this repo and `~/.claude` points at it —
+and read cold that looks like an inconsistency rather than a decision.
+
+It is a decision. Both shapes are correct, for different files, and which one a
+file gets is not a matter of taste. This page is the test.
+
+## Path A — declare and generate
+
+Nix owns the content. The artifact's home is a tree we do not control, or one
+that must not be in git, so the repo holds a *declaration* and activation turns
+it into the real thing.
+
+Three variants are already in the tree:
+
+| | |
+|---|---|
+| Store symlink | `modules/desktop/raycast` renders the script commands into `~/.config/raycast/scripts`. Read-only is fine; Raycast only reads them. |
+| Copy, writable | `modules/programs/datagrip` copies `dataSources.xml` in with `install`. It cannot symlink: the IDE rewrites that file whenever a datasource changes, and the store is read-only. Drift between switches is the accepted cost, and its header argues this out at length. |
+| Intercept the imperative act | `modules/homebrew/nix-brew.sh` (#35). `brew tap` and `brew install` keep working; the wrapper writes the pin into `modules/homebrew/taps.nix` or `hosts/<host>/homebrew-generated.nix`, and `brew drift` lists what escaped. |
+
+The cost is an interception layer, drift detection, and a rebuild before a
+change takes effect.
+
+## Path B — adopt in place
+
+The repo holds the real file. Nix only points the program's expected path at it,
+with `config.lib.file.mkOutOfStoreSymlink`, and then has no further role.
+`modules/programs/claude-code` is the only one today.
+
+The payoff is that drift is structurally impossible, because there is one copy
+of the file. A skill written into `~/.claude/skills` is an untracked file in this
+repo the moment it is saved. No rebuild, and nothing to remember.
+
+The costs are real and worth knowing before you pick this:
+
+- **`git` moves live configuration.** Checking out an older commit rewrites the
+  skills of any Claude Code session running at that moment. `git clean -fdx`
+  deletes them.
+- **Nix cannot template the file.** No host-specific values, no `mine.user.email`
+  interpolated in, and no way to give a fork a different copy. If a file ever
+  needs to vary, it moves to Path A.
+- **No prompt between typing and versioning.** A credential typed into the file
+  is in the working tree immediately. The claude-code module scans for the keys
+  that hold one and warns, which is mitigation, not a fix.
+- **The path is hardcoded.** `mkOutOfStoreSymlink` bakes in the checkout
+  location. Move the repo and the symlinks dangle.
+
+## The test
+
+In order. The first one usually settles it.
+
+**1. Can the artifact live in this repo?**
+
+No means Path A, and it is normally obvious why: a foreign tree
+(`/opt/homebrew/Cellar`), a root-owned store symlink (`Taps`), or a file that is
+mostly machine state (`~/.claude.json` is 85 KB of caches, telemetry,
+`oauthAccount` and per-project history around a few lines of config).
+
+**2. Is there a declaration meaningfully shorter than the artifact that
+reproduces it losslessly?**
+
+Yes means Path A pays for itself. `"deskflow"` reproduces an entire Homebrew
+install — that asymmetry is the whole return on the generation layer.
+
+No means Path B. The shortest thing that reproduces a `SKILL.md` is the
+`SKILL.md`; a generation layer would "declare" the file by storing the file and
+then copy it into place, which is ceremony plus a rebuild in exchange for
+nothing.
+
+**3. Does the program tolerate a symlink and write through it in place?**
+
+No means Path A, copy variant, and you accept the drift. DataGrip is the
+cautionary case. Claude Code was tested and does: it followed the symlink,
+preserved it, and merged its write rather than clobbering the file.
+`CLAUDE_CONFIG_DIR` points Claude Code at a throwaway config directory, which
+makes this cheap to check rather than assume — the equivalent for another
+program is worth finding before committing to Path B.
+
+Frequency is not a criterion but it is an amplifier. It decides how much
+ceremony Path A can carry before it gets bypassed in practice. `brew install` is
+occasional, so `nix-brew` can afford a three-way prompt on every call. Skills get added
+most days, often by Claude itself mid-session, so anything per-skill would
+simply be skipped — and a drift-control layer that gets skipped is worse than
+none, because it looks like it is working.
+
+## One feature, both paths
+
+`modules/programs/claude-code` is the useful example precisely because it needs
+each path for a different file, decided by test 1 alone:
+
+- `settings.json`, `skills/`, `CLAUDE.md` — Path B. Ordinary files at a path we
+  control.
+- MCP servers — Path A. They live only in `~/.claude.json`, which fails test 1,
+  so the repo holds `mcp-servers.json`, activation merges it in, and anything
+  `claude mcp add` leaves on disk is written back into the repo file so it turns
+  up in `git status`.
+
+The boundary is not philosophical. It is decided per file, by where that file
+has to live.

--- a/hosts/David-M3-Pro/default.nix
+++ b/hosts/David-M3-Pro/default.nix
@@ -56,6 +56,11 @@
     email = "david@wemaintain.com";
   };
 
+  # Claude Code's skills, settings and MCP servers (#36). The WeMaintain MCP
+  # servers come from the work block above; this flag is what wires ~/.claude
+  # to modules/config/claude.
+  mine.programs.claude-code.enable = true;
+
   # DataGrip (#7). The WeMaintain datasources come from the block above; only
   # what is personal to this machine is listed here.
   mine.programs.datagrip = {
@@ -93,7 +98,8 @@
       "zed"
       "openlens"
       "warp"
-
+      "claude-code"
+      "claude"
       # Communication
       "discord"
       "signal"

--- a/hosts/David-M4-Max/default.nix
+++ b/hosts/David-M4-Max/default.nix
@@ -56,6 +56,11 @@
     email = "david@wemaintain.com";
   };
 
+  # Claude Code's skills, settings and MCP servers (#36). The WeMaintain MCP
+  # servers come from the work block above; this flag is what wires ~/.claude
+  # to modules/config/claude.
+  mine.programs.claude-code.enable = true;
+
   # DataGrip (#7). The WeMaintain datasources come from the block above; only
   # what is personal to this machine is listed here.
   mine.programs.datagrip = {

--- a/modules/README.md
+++ b/modules/README.md
@@ -6,7 +6,7 @@ Everything here runs on macOS (aarch64-darwin). There is no `shared` /
 ## Layout
 ```
 .
-├── config/                # Config files not written in Nix (emacs, raycast)
+├── config/                # Config files not written in Nix (emacs, raycast, claude)
 ├── desktop/               # Window management & display: aerospace, betterdisplay,
 │                          # dock, sketchybar
 ├── services/              # Nix-darwin services (screen-lock-monitor)
@@ -16,8 +16,11 @@ Everything here runs on macOS (aarch64-darwin). There is no `shared` /
 ├── secrets.nix            # agenix secrets
 ├── home-manager.nix       # The nix-darwin module wiring up home-manager
 ├── programs/              # home-manager programs (git, zsh, vim, tmux, ssh, ...),
-│                          # plus datagrip/, which is a nix-darwin module (it owns
-│                          # both the cask and the IDE's datasource file)
+│                          # plus two nix-darwin modules: datagrip/ (owns both the
+│                          # cask and the IDE's datasource file) and claude-code/
+│                          # (points ~/.claude back at config/claude — see
+│                          # docs/two-paths.md, it is the one module here that
+│                          # does not generate what it manages)
 ├── files.nix              # Non-Nix, static configuration files (now immutable!)
 ├── homebrew/              # Homebrew policy; the lists come from mine.homebrew.*
 │   ├── nix-brew.sh        #   `brew tap`/`install` wrapper that records the pin (#35)

--- a/modules/config/claude/mcp-servers.json
+++ b/modules/config/claude/mcp-servers.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "linear-server": {
+      "type": "http",
+      "url": "https://mcp.linear.app/mcp"
+    },
+    "datagrip": {
+      "url": "http://127.0.0.1:64402/stream",
+      "type": "http"
+    }
+  }
+}

--- a/modules/config/claude/readme.md
+++ b/modules/config/claude/readme.md
@@ -1,0 +1,26 @@
+# Claude Code configuration
+
+These files are not copied or generated. `~/.claude/settings.json`,
+`~/.claude/CLAUDE.md` and `~/.claude/skills` are symlinks pointing here, made by
+`modules/programs/claude-code` — so the file Claude Code reads and the file git
+tracks are the same file, and adding a skill needs no rebuild.
+
+| | |
+|---|---|
+| `settings.json` | Written by Claude Code itself. Approving a permission or installing a plugin shows up here as a `git diff`. |
+| `skills/` | One directory per skill. Anything created in `~/.claude/skills` lands here as an untracked file. |
+| `CLAUDE.md` | Global instructions, prepended to every session. Shipped empty. |
+| `mcp-servers.json` | The exception: MCP servers live in `~/.claude.json`, which is mostly machine state and cannot be symlinked, so this one *is* merged in at activation. `claude mcp add` still works — the next `build-switch` writes what it added back into this file. |
+
+Two things to know, both explained in `docs/two-paths.md`:
+
+- **`git` moves live configuration.** Checking out an older commit rewrites the
+  skills of a running session; `git clean -fdx` deletes them.
+- **This is versioned the instant you type it.** Nothing sits between
+  `settings.json` and the working tree, so no credential belongs in it. The
+  activation warns about `env`, `apiKeyHelper` and `awsAuthRefresh`, and refuses
+  to adopt MCP servers carrying `headers` or `env`.
+
+WeMaintain's MCP servers are not here. They are in `modules/work/wemaintain`,
+behind `mine.work.wemaintain.enable`, so a fork does not inherit endpoints it
+has no account for.

--- a/modules/config/claude/settings.json
+++ b/modules/config/claude/settings.json
@@ -1,0 +1,69 @@
+{
+  "includeCoAuthoredBy": false,
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:docs.airbyte.com)",
+      "Read(//Users/david/.claude/skills/**)",
+      "Read(//Users/david/.agents/skills/handoff/**)",
+      "mcp__linear-server__list_teams",
+      "mcp__linear-server__list_initiatives",
+      "mcp__linear-server__save_project",
+      "mcp__linear-server__save_issue",
+      "mcp__linear-server__list_issue_labels",
+      "mcp__linear-server__create_issue_label",
+      "WebSearch",
+      "WebFetch(domain:aws.amazon.com)",
+      "mcp__linear-server__save_comment",
+      "Bash(gcloud config *)",
+      "Bash(gcloud projects *)",
+      "Read(//private/tmp/**)",
+      "Bash(timeout 90 gcloud auth print-access-token --impersonate-service-account=dbt-cloud@data-stack-389913.iam.gserviceaccount.com)",
+      "Read(//codex/snippets/**)",
+      "Read(//codex/characters/**)",
+      "Bash(npx vitest *)",
+      "Bash(npm install *)",
+      "Bash(npm run *)",
+      "Bash(npx playwright *)",
+      "Bash(npx prettier *)",
+      "Bash(git commit *)",
+      "Bash(gh issue *)",
+      "Bash(python3 -)"
+    ]
+  },
+  "model": "opus[1m]",
+  "enabledPlugins": {
+    "chrome-devtools-mcp@claude-plugins-official": true,
+    "datadog@claude-plugins-official": true,
+    "mattpocock-skills@claude-plugins-official": true,
+    "sam@claude": true,
+    "slack@claude-plugins-official": true,
+    "miro@claude-plugins-official": true,
+    "avoid-ai-writing@conorbronsdon-skills": true,
+    "nopus@nopus": true
+  },
+  "extraKnownMarketplaces": {
+    "claude": {
+      "source": {
+        "source": "directory",
+        "path": "/Users/david/wmtn/backend/packages/claude"
+      }
+    },
+    "conorbronsdon-skills": {
+      "source": {
+        "source": "github",
+        "repo": "conorbronsdon/avoid-ai-writing"
+      }
+    },
+    "nopus": {
+      "source": {
+        "source": "github",
+        "repo": "Vistyy/nopus"
+      }
+    }
+  },
+  "effortLevel": "medium",
+  "switchModelsOnFlag": false,
+  "agentPushNotifEnabled": true
+}

--- a/modules/config/claude/skills/writing-shaping-docs/EXAMPLES.md
+++ b/modules/config/claude/skills/writing-shaping-docs/EXAMPLES.md
@@ -1,0 +1,79 @@
+# Before → after: real failures from a reviewed shaping doc
+
+Each pair below is genericized from a real shaping document and the reviewer comments it drew. The "before" versions were all written by an agent; every one earned a comment.
+
+## 1. Undefined acronym
+
+**Before:** "pushing a SoR quote out the door is cumbersome"
+
+**Reviewer:** *"What is a SoR quote?"* — asked by a stakeholder, on the second paragraph.
+
+**After:** first use reads "a client's contractual Schedule of Rates (SoR)"; every later use is bare "SoR".
+
+## 2. Pointer instead of fact
+
+**Before:** "Price-list maintenance at v1 is a CLI a dev runs — this supersedes the discovery statement that a self-service maintenance path is non-optional."
+
+**Reviewer:** *"As a first-time reader with no clue about the discovery statement, I don't understand this."*
+
+**After:** "Price-list maintenance at v1 is a CLI a dev runs. Until an authoring UI ships (a follow-up project), a reprice needs an engineer — a risk we accept knowingly." The decision and its consequence are on the page; the discovery document is not.
+
+## 3. Future-roadmap hook
+
+**Before:** "…those states fall out of the decision the CSM already made, and they are the hook that later rate enforcement and evidence gating hang on."
+
+**Reviewer:** *"Completely non-understandable by people that don't have the context / don't know the future epics."*
+
+**After:** cut the clause. The states justify themselves in the present; if the forward link truly matters, it gets its own self-contained sentence ("a later project can enforce rates because every line records where its price came from").
+
+## 4. Provenance noise
+
+**Before:** "Interactive prototype — a carbon copy of the repair-request page with the picker layered in."
+
+**Reviewer:** *"Why say that? Sure it was part of the ticket that originated it, but why would a first-time reader of the shaping care?"*
+
+**After:** "Interactive prototype — the repair-request page with the picker layered in." What the artifact *is*, not how it was produced.
+
+## 5. Clever prose where bullets belong
+
+**Before:** "`RequestItem.price` means *cost to us*. `RequestItem.sellPrice` is what we charge. Confusing, pre-existing; `sellPrice` becomes `@deprecated` with this project, since the picker's action is creating a `QuoteLine` and never writes it."
+
+**Reviewer:** *"What's confusing is this prose."* The reviewer rewrote it themselves:
+
+**After:**
+> - `RequestItem.price` should be renamed (not now) `RequestItem.cost`
+> - `RequestItem.sellPrice` (a hack from before quote lines existed in our backend) is deprecated. We never write to it again.
+
+Facts in a list read as facts. The same facts woven into prose read as a riddle.
+
+## 6. Micro-decision in the doc
+
+**Before:** "`sortOrder` deferred."
+
+**Reviewer:** *"Useless."*
+
+**After:** deleted. The deferral lives in the ticket that owns the field.
+
+## 7. Insider shorthand
+
+**Before:** "Computed-vs-recorded is the top-level division; the long tail (indexation formulas, caps, allowances, billing trigger) lives as text in `notes`."
+
+**Reviewer:** *"Absolutely not understandable without context."* Twice, on two adjacent sentences.
+
+**After:** either spell it out — "Lines the system can price (rates, coefficients) are structured rows; everything it only needs to remember (indexation formulas, caps, allowances) is prose in a `notes` field" — or leave it to the ticket where the division is defined.
+
+## 8. The deep dive parked mid-document
+
+**Before:** a full data-model section (five tables, aggregate design, migration plan, FK semantics) sat directly after the solution section, at equal rank with it.
+
+**Reviewer:** *"This whole paragraph might be way too verbose. This should be an 'overview' and deep dives happen in each wayfinder ticket."* And: *"I moved it manually — it should be treated as an annex more than anything else."*
+
+**After:** the main body ends at boundaries and open questions. The data model — make-or-break for this project, which is the only reason it appears at all — becomes an annex holding the entities, their relations, and the two load-bearing decisions, with each subsection linking to the wayfinder ticket that carries the full dive.
+
+## 9. Solution section that describes the system, not the outcome
+
+**Before:** the solution section led with field-authoring semantics, FK cardinalities, and Salesforce viability notes ("`QuoteLine` fields are authored at pick time…", "free-floating quote lines are viable in Salesforce…").
+
+**Reviewer:** *"Way too verbose, way not solution/outcome centered."* The reviewer moved every one of those paragraphs out of the solution into the data-model annex.
+
+**After:** the solution narrates the user's workflow: "The CSM opens the request as today, and for every item makes exactly one decision: take the contracted rate, price it off-list, or leave it out of the quote. No PDF to hunt down, no re-typing a price we already agreed with the client." The tables that make it work are the annex's business.

--- a/modules/config/claude/skills/writing-shaping-docs/SKILL.md
+++ b/modules/config/claude/skills/writing-shaping-docs/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: writing-shaping-docs
+description: Write up an already-shaped project as a shaping document (e.g. a Linear project description) — the write-up craft, not the shaping process.
+disable-model-invocation: true
+---
+
+The shaping is done: the exploration happened, the decisions are made, wayfinder tickets exist. This skill governs the **write-up** — packaging what the shapers know so a **cold reader** reaches the same a-ha they had. The document is judged by whether the cold reader gets there, never by template completeness.
+
+## The two readers
+
+Every paragraph serves two readers at once, and both are cold — they weren't in the shaping room, haven't read the discovery, don't know the roadmap:
+
+1. **The stakeholder** — smart, fluent in the business, technically literate but indifferent to implementation. Reads for problem, why, and solution.
+2. **The dev** — strong technically, short on business context. Needs the why to understand the work, then the solution and its boundaries.
+
+Write for whichever of the two knows less about the sentence you're writing. The stakeholder gates the main body; the dev gates the annex.
+
+**Cold-reader rules** (each one is a real failure a reviewer flagged — see [EXAMPLES.md](EXAMPLES.md)):
+
+- Expand every acronym and domain term at first use.
+- A sentence that leans on prior work must carry the fact, not the pointer. "This supersedes the discovery statement that X" is unreadable cold; state the decision and its consequence, in place.
+- Future plans get mentioned only when the sentence explains itself without the roadmap. "These states are the hook later enforcement hangs on" assumes the reader knows the later epics — either give the one-line context or cut.
+- Provenance is noise. How the doc, prototype, or decision came to be ("a carbon copy of...", "this was originally in the ticket that...") matters to the authors, not the readers.
+
+## Altitude — what goes where
+
+The document is the top of a stack, and each layer has an owner:
+
+| Layer | Carries | Reader |
+|---|---|---|
+| Main body | Problem → why → solution, readable end-to-end | Both, led by the stakeholder |
+| Boundaries | Out of scope, open questions | Both |
+| Annex | **Overview** of make-or-break technicals | The dev |
+| Wayfinder tickets | Full depth, micro-decisions, sequencing | The dev who picks up the ticket |
+
+- The annex exists only for material the project stands or falls on (a data model that is make-or-break, a migration that constrains everything). It stays an overview — the entities, the relations, the one or two load-bearing decisions — and links to the tickets that carry the dives. If the main body depends on the annex to be understood, the body is broken.
+- Sequencing and dependencies live in the ticket graph. Mention a dependency in the doc only when it shaped the solution itself.
+- Micro-decisions ("field X deferred", a naming call) live in the ticket that owns them. In the doc they are pure noise.
+
+An example skeleton — an example, not a template; shape sections to the project:
+
+> Problem / Why now / The solution / Out of scope / Still to settle / Annex: *the make-or-break thing*, overview
+
+## Section craft
+
+- **Problem** — open with one specific story that shows why the status quo fails (the customer who did the absurd workaround), then generalize minimally. Numbers only if already quantified; a shaping doc re-litigates nothing.
+- **Why** — connect to the company priority and the prize. Settle "why now" and "why this is the dependency" in a few sentences each.
+- **Solution** — outcome-centered: narrate what the user does and what they get, in workflow order. Annotated screenshots or prototype captures carry it. Mechanics and data shapes stay out of this section entirely.
+- **Out of scope** — explicit exclusions that tell the team where to stop, each with its one-line reason.
+- **Still to settle** — genuinely open questions, each with where it gets decided.
+- **Annex** — the overview described above.
+
+## Prose
+
+- Short declarative sentences, one idea each. A sentence packing three facts behind em-dashes reads as clever to the author and opaque to everyone else.
+- When the content is a set of facts (states, field meanings, rules), write bullets, not woven prose. Prose implies flow; a list implies a list.
+- Every sentence must matter to at least one of the two readers. A sentence that matters to neither — however true — gets cut, not compressed.
+- Use the project's ubiquitous language, defined at first use, then never varied for elegance.
+- Bold marks the sentence a skimmer must not miss — at most one per paragraph.
+
+## The cold-reader pass
+
+After drafting, reread the whole document twice — once as each reader — and fix what fails. Done when:
+
+- every acronym and term of art is defined at its first occurrence;
+- every sentence survives with zero knowledge of the discovery, prior tickets, or future epics;
+- the main body reads end-to-end with the annex deleted;
+- every technical detail sits at its altitude — body, annex overview, or ticket — with none orphaned in between.
+
+For before→after pairs of the failures these rules exist to prevent, read [EXAMPLES.md](EXAMPLES.md) while drafting or reviewing.

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -13,6 +13,8 @@ in
    # A nix-darwin module despite living in modules/programs: it owns both the
    # cask and the datasource file. See its header.
    ./programs/datagrip
+   # Likewise: it owns home files and an option the work module contributes to.
+   ./programs/claude-code
   ];
 
   # It me

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -87,6 +87,17 @@
   # things that arrange your screen. The datasource schema that goes with this
   # flag is declared in modules/programs/datagrip, which is where it is used.
   options.mine.programs = {
+    claude-code.enable = lib.mkEnableOption ''
+      Claude Code's configuration: `~/.claude/settings.json`, `~/.claude/skills`
+      and `~/.claude/CLAUDE.md` become symlinks to modules/config/claude, so the
+      files Claude Code reads are the files this repo tracks and a skill added
+      by hand is versioned without a rebuild. Also merges the MCP server list
+      into `~/.claude.json`, which cannot be symlinked because it is mostly
+      machine state. Does not install Claude Code itself — that is a cask, named
+      in `hosts/<hostname>`. See docs/two-paths.md for why this module is shaped
+      unlike every other one here
+    '';
+
     datagrip.enable = lib.mkEnableOption ''
       DataGrip: installs the cask and applies
       `mine.programs.datagrip.datasources` as global datasources, so the same

--- a/modules/programs/claude-code/default.nix
+++ b/modules/programs/claude-code/default.nix
@@ -1,0 +1,224 @@
+# Claude Code's configuration: skills, settings, and the MCP server list (#36).
+#
+# This is a *nix-darwin* module, not a home-manager one, for the same reason
+# modules/programs/datagrip is: it owns files in the home directory and an
+# option that modules/work/wemaintain contributes to, and both belong to the
+# same "I use Claude Code" switch. It is imported by modules/home-manager.nix
+# and deliberately not by modules/programs/default.nix.
+#
+#
+# THIS MODULE GENERATES ALMOST NOTHING, WHICH IS THE POINT
+#
+# Everything else in this repo owns the content of the files it manages and
+# renders them from nix. This module mostly does not: `~/.claude/settings.json`
+# and `~/.claude/skills` are symlinks pointing *back into the working tree* at
+# modules/config/claude, so the file Claude Code reads and the file git tracks
+# are the same file.
+#
+# That is the "adopt in place" path in docs/two-paths.md, and it is chosen here
+# because skills get written most days — often by Claude itself, mid-session.
+# Any workflow with a per-skill step (declare it, rebuild, re-run) is a step
+# that gets skipped, and then the drift this module exists to kill is back.
+# Under the symlinks there is only ever one copy of the file, so a skill written
+# tomorrow is an untracked file in this repo the moment it is saved, and an
+# "always allow" is a `git diff`. Nothing to remember and no rebuild.
+#
+# Three things had to be true for this to work, and all three were tested
+# rather than assumed (`CLAUDE_CONFIG_DIR` points Claude Code at a throwaway
+# config directory, which is how):
+#
+#   - Claude Code writes settings.json *in place*, following the symlink rather
+#     than replacing it, and merges its change instead of clobbering the file.
+#   - Skill discovery follows symlinks.
+#   - `mcpServers` in settings.json is ignored. It is read only from
+#     ~/.claude.json, which is why that one is handled differently below.
+#
+# The costs, which are real:
+#
+#   - `git` now moves live configuration. Checking out an older commit rewrites
+#     the skills of any Claude Code session running at that moment, and
+#     `git clean -fdx` deletes them.
+#   - nix cannot template these files per host. There is no way to give a fork
+#     a different settings.json, so `enabledPlugins` and `extraKnownMarketplaces`
+#     in there are simply David's, and a fork is expected to edit them.
+#   - Anything typed into settings.json or a skill is in the working tree
+#     immediately, with no prompt in between. See the secret scan below.
+#
+#
+# MCP SERVERS TAKE THE OTHER PATH
+#
+# They live only in ~/.claude.json: 85 KB of mostly machine state — caches,
+# telemetry, `oauthAccount`, per-project history. That file cannot be a symlink
+# into a git repo, so its configuration gets generated and merged instead:
+#
+#   modules/config/claude/mcp-servers.json  the personal servers, hand-edited
+#   mine.programs.claude-code.extraMcpServers  contributed by other modules,
+#                                              which is how the WeMaintain ones
+#                                              arrive behind their own flag
+#
+# The activation below merges both into ~/.claude.json, preserving every other
+# key. And because `claude mcp add` still works and still writes only to
+# ~/.claude.json, it also does the reverse: a server found on disk that nothing
+# declares is appended to mcp-servers.json, so it turns up in `git status`
+# rather than being lost on the next machine. Servers carrying `headers` or
+# `env` are never written back — that is where `claude mcp add --header
+# "Authorization: Bearer …"` would put a token.
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.mine.programs.claude-code;
+  user = config.mine.user.name;
+  home = config.users.users.${user}.home;
+
+  claudeDir = "${cfg.repoPath}/modules/config/claude";
+
+  # The nix-contributed half of the MCP list. Rendered to the store because it
+  # is generated; the hand-edited half stays a file in the working tree and is
+  # read at activation time, so editing it needs no rebuild.
+  extraMcpFile =
+    pkgs.writeText "claude-extra-mcp-servers.json" (builtins.toJSON cfg.extraMcpServers);
+in
+{
+  # `mine.programs.claude-code.enable` is declared in modules/options.nix with
+  # the other feature flags. These two are declared here, where they are used.
+  options.mine.programs.claude-code = {
+    repoPath = lib.mkOption {
+      type = lib.types.str;
+      default = "${home}/.config/nixos-config";
+      description = ''
+        Absolute path to this repo's working tree on this machine.
+
+        Unavoidably a path and not a store reference: the whole point is that
+        `~/.claude` points at files you can edit without rebuilding, which a
+        store path cannot be. Move or rename the checkout and `~/.claude` is
+        left pointing at nothing — the activation checks for that and says so.
+      '';
+    };
+
+    extraMcpServers = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.attrsOf lib.types.anything);
+      default = { };
+      example = {
+        sentry = { type = "http"; url = "https://mcp.sentry.dev/mcp"; };
+      };
+      description = ''
+        MCP servers contributed by other modules, merged into `~/.claude.json`
+        on top of modules/config/claude/mcp-servers.json.
+
+        This is the seam for servers that belong to a flag rather than to the
+        person: `mine.work.wemaintain` puts its gateways here so a fork does not
+        inherit endpoints it has no account for. Servers declared this way are
+        never written back to mcp-servers.json, since nix already owns them.
+
+        Nothing secret goes here — it is rendered into the world-readable nix
+        store. Auth is Claude Code's own OAuth, kept in the macOS keychain.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home-manager.users.${user} = { config, lib, ... }: {
+      # Out-of-store symlinks: the target is the working tree, not the store,
+      # so Claude Code can write through them and the writes land in git.
+      #
+      # home-manager moves anything already at these paths aside as
+      # `.before-nix` (backupFileExtension in modules/home-manager.nix), so the
+      # first build-switch on a machine that already had a ~/.claude keeps a
+      # copy of what was there.
+      home.file = {
+        ".claude/settings.json".source =
+          config.lib.file.mkOutOfStoreSymlink "${claudeDir}/settings.json";
+
+        # Global instructions, prepended to every session. Shipped empty; it is
+        # a seam rather than a suggestion.
+        ".claude/CLAUDE.md".source =
+          config.lib.file.mkOutOfStoreSymlink "${claudeDir}/CLAUDE.md";
+
+        # The whole directory, not one entry per skill: a new skill has to be
+        # able to appear here without nix knowing its name in advance, which is
+        # the entire reason this module is shaped this way.
+        ".claude/skills".source =
+          config.lib.file.mkOutOfStoreSymlink "${claudeDir}/skills";
+      };
+
+      home.activation.claudeMcpServers = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        jq=${pkgs.jq}/bin/jq
+        claudeDir="${claudeDir}"
+        repoMcp="$claudeDir/mcp-servers.json"
+        target="$HOME/.claude.json"
+
+        if [ ! -d "$claudeDir" ]; then
+          # The symlinks above have already been made and are now dangling, so
+          # Claude Code will come up with no settings and no skills. Say so
+          # loudly: the failure is otherwise silent and looks like data loss.
+          echo "claude-code: ${claudeDir} does not exist." >&2
+          echo "claude-code: ~/.claude/{settings.json,skills} are dangling symlinks and Claude Code" >&2
+          echo "claude-code: will start with no configuration. Either move the checkout back, or set" >&2
+          echo "claude-code: mine.programs.claude-code.repoPath to where it actually is." >&2
+        else
+          # ~/.claude.json is Claude Code's own state file and is created on
+          # first run. Seeding an empty object is enough for the merge below;
+          # Claude Code fills in the rest.
+          if [ ! -e "$target" ]; then
+            $DRY_RUN_CMD install -m 0600 /dev/null "$target"
+            echo '{}' | $DRY_RUN_CMD tee "$target" > /dev/null
+          fi
+
+          # Everything nix and the repo file declare between them.
+          declared=$($jq -s '(.[0].mcpServers // {}) * (.[1] // {})' \
+            "$repoMcp" ${extraMcpFile})
+
+          # Merge into ~/.claude.json. Declared servers win; every other key in
+          # that file, and every server nobody declares, is left alone.
+          merged=$(mktemp)
+          $jq --argjson declared "$declared" \
+            '.mcpServers = ((.mcpServers // {}) * $declared)' "$target" > "$merged"
+          if ! ${pkgs.diffutils}/bin/diff -q "$merged" "$target" > /dev/null 2>&1; then
+            $DRY_RUN_CMD install -m 0600 "$merged" "$target"
+          fi
+          rm -f "$merged"
+
+          # The reverse direction: anything `claude mcp add` put on disk that
+          # nothing declares. Written back into the working tree so it shows up
+          # in `git status` instead of being lost with the machine.
+          undeclared=$($jq --argjson declared "$declared" \
+            '(.mcpServers // {}) | with_entries(select(.key as $k | ($declared | has($k)) | not))' \
+            "$target")
+
+          # `claude mcp add --header "Authorization: Bearer …"` and `-e KEY=…`
+          # both land in the server entry. Never copy those into a git repo.
+          withSecrets=$($jq -r 'to_entries | map(select(.value.headers or .value.env)) | .[].key' \
+            <<< "$undeclared")
+          if [ -n "$withSecrets" ]; then
+            echo "claude-code: not adopting MCP servers that carry headers or env, which is where" >&2
+            echo "claude-code: credentials live. Declare them by hand without the secret if you want" >&2
+            echo "claude-code: them versioned:" >&2
+            echo "$withSecrets" | sed 's/^/claude-code:   /' >&2
+          fi
+
+          adoptable=$($jq 'with_entries(select((.value.headers or .value.env) | not))' <<< "$undeclared")
+          if [ "$(${pkgs.jq}/bin/jq -r 'length' <<< "$adoptable")" != "0" ]; then
+            adopted=$(mktemp)
+            $jq --argjson new "$adoptable" \
+              '.mcpServers = ((.mcpServers // {}) * $new)' "$repoMcp" > "$adopted"
+            $DRY_RUN_CMD install -m 0644 "$adopted" "$repoMcp"
+            rm -f "$adopted"
+            echo "claude-code: adopted into $repoMcp (unstaged, commit when you are ready):"
+            ${pkgs.jq}/bin/jq -r 'keys[]' <<< "$adoptable" | sed 's/^/claude-code:   /'
+          fi
+
+          # settings.json is live-symlinked into the repo, so a credential typed
+          # into it is in the working tree with nothing in between. These three
+          # keys are the ones that hold or fetch one.
+          secretKeys=$($jq -r '[paths(scalars) as $p | $p[0]] | unique
+            | map(select(. == "env" or . == "apiKeyHelper" or . == "awsAuthRefresh")) | .[]' \
+            "$claudeDir/settings.json" 2>/dev/null || true)
+          if [ -n "$secretKeys" ]; then
+            echo "claude-code: settings.json sets $(echo "$secretKeys" | tr '\n' ' ')— check no" >&2
+            echo "claude-code: credential is about to be committed. This file is versioned." >&2
+          fi
+        fi
+      '';
+    };
+  };
+}

--- a/modules/work/wemaintain/default.nix
+++ b/modules/work/wemaintain/default.nix
@@ -561,6 +561,54 @@ in
       })
       (lib.filterAttrs (_: db: db.datagrip.enable) cfg.databases);
 
+    # The MCP servers Claude Code talks to for work, merged into ~/.claude.json
+    # by modules/programs/claude-code. They are here rather than in that
+    # module's mcp-servers.json for the same reason the Pritunl cask is here:
+    # a Looker instance at wemaintain.cloud.looker.com and three Bedrock
+    # AgentCore gateways are WeMaintain's, and a fork has no account for any of
+    # them. Same story as the rest of this module — endpoints only, no
+    # credentials; Claude Code does OAuth against these and keeps the tokens in
+    # the macOS keychain.
+    #
+    # The claude-code module ignores this when it is off, so nothing is gated.
+    mine.programs.claude-code.extraMcpServers = {
+      datadog-mcp = {
+        type = "http";
+        # The EU site: WeMaintain's Datadog org lives there, and the US
+        # endpoint would 404 against it.
+        url = "https://mcp.datadoghq.eu/v1/mcp";
+      };
+
+      looker = {
+        type = "http";
+        url = "https://wemaintain.cloud.looker.com/mcp";
+        # Looker wants a registered OAuth client and a fixed loopback port to
+        # hand the code back to; both are public, the token is not and is not
+        # here.
+        oauth = {
+          clientId = "2f98abc6-3789-4c86-bdf1-1a5be9b83b78";
+          callbackPort = 8080;
+        };
+      };
+
+      # Bedrock AgentCore gateways. The host names are generated per gateway
+      # and cannot be derived from anything, so they are written out.
+      mcp-db = {
+        type = "http";
+        url = "https://mcp-prodeng-mcp-gateway-ppqa4f3owf.gateway.bedrock-agentcore.eu-west-1.amazonaws.com/mcp";
+      };
+
+      mcp-graphql = {
+        type = "http";
+        url = "https://mcp-mcp-gateway-aq3foghq4u.gateway.bedrock-agentcore.eu-west-1.amazonaws.com/mcp";
+      };
+
+      mcp-wm-prodeng-staging = {
+        type = "http";
+        url = "https://mcp-prodeng-mcp-gateway-1grpyouq7z.gateway.bedrock-agentcore.eu-west-1.amazonaws.com/mcp";
+      };
+    };
+
     # /etc/zshenv is fought over by two other tools:
     #   - tech.bastion.aiproxy (Bastion, the endpoint agent WeMaintain deploys)
     #     appends its HTTPS_PROXY / NODE_EXTRA_CA_CERTS exports

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,9 @@ name matches `hostname -s`; pass a host name to build another one, e.g.
 keys nothing can regenerate from the old one (`nix run .#keys`). On a factory
 Mac, `curl -fsSL https://raw.githubusercontent.com/Superd22/Nix-Config/main/bootstrap.sh | sh`
 runs the whole thing as a wizard (`bootstrap.sh`, then `nix run .#init`).
+**docs/two-paths.md** why most modules generate the files they manage and
+`modules/programs/claude-code` instead points `~/.claude` back into this repo —
+and how to tell which shape a new module wants.
 **hosts** one directory per machine, named after its hostname, plus
 `hosts/common` for the darwin config they share. Each becomes
 `darwinConfigurations.<hostname>`.


### PR DESCRIPTION
Closes #36.

`~/.claude` was not tracked at all, which is what the M3 -> M4 move lost. This versions the configuration third of it and leaves the 1.4 GB of machine state (`projects/`, `plugins/`, `file-history/`, transcripts, telemetry) alone.

## The shape, and why it is not the usual one

Every other module here generates the file it manages. This one mostly does not — `~/.claude/settings.json`, `~/.claude/CLAUDE.md` and `~/.claude/skills` are `mkOutOfStoreSymlink`s into `modules/config/claude`, so the file Claude Code reads and the file git tracks are the same file.

That is deliberate and argued out in #36. Skills get written most days, often by Claude itself mid-session; any per-skill step (declare, rebuild, re-run) is a step that gets skipped, and a drift-control layer that gets skipped is worse than none because it looks like it is working. Under the symlinks there is only ever one copy of the file, so drift is structurally impossible: a skill written tomorrow is an untracked file in this repo the moment it is saved, and an "always allow" is a `git diff`.

Three behaviours this rests on were tested against a throwaway `CLAUDE_CONFIG_DIR` rather than assumed:

- Claude Code writes `settings.json` **in place through the symlink**, keeping the link and merging its change instead of clobbering the file.
- Skill discovery **follows symlinks**.
- `mcpServers` in `settings.json` is **ignored** — it is read only from `~/.claude.json`.

## MCP servers take the other path, which is the point

They live only in `~/.claude.json`: 85 KB of caches, telemetry, `oauthAccount` and per-project history around a few lines of config. That file cannot be a symlink into a git repo, so it gets the generate-and-merge treatment instead — `mcp-servers.json` in the repo, merged in at activation, with `mine.programs.claude-code.extraMcpServers` as the seam other modules contribute through.

It also runs in reverse: a server `claude mcp add` left on disk that nothing declares is **appended to the repo file**, so it turns up in `git status` rather than dying with the machine. Servers carrying `headers` or `env` are never adopted — that is exactly where `claude mcp add --header "Authorization: Bearer …"` puts a token.

One feature needing both shapes is the argument for documenting them as a pair, so **`docs/two-paths.md`** gives the test — can the artifact live in the repo, is there a declaration meaningfully shorter than it, does the program tolerate a symlink — and places the three Path A variants already in the tree (raycast's store symlinks, datagrip's writable copy, #35's interception) against this one.

## Verified

The five activation cases were run against a sandbox `HOME` using the *generated* script, not a reimplementation of it:

| | |
|---|---|
| Fresh machine, no `~/.claude.json` | all 7 servers restored; work servers correctly **not** written back to the repo file |
| Undeclared server on disk | adopted into `mcp-servers.json`, reported by name |
| Undeclared server with a bearer token | refused with a warning, left working on disk, **no secret in the repo** |
| Second run | quiet and idempotent |
| Checkout moved away | dangling symlinks reported explicitly, rather than Claude Code silently starting with no config |

`darwinConfigurations.David-M3-Pro.system` builds and the two-hop symlink resolves to the working tree as intended; `David-M4-Max` and `example` both evaluate, rebased on #35.

## Also in here

- `hosts/David-M3-Pro` was missing the `claude-code` and `claude` casks the M4 host has, so both now declare them. (They are not otherwise in sync — main has since given the M4 `nvm` and `ferdium`, which this branch leaves alone.)
- `.gitignore` gets `.claude/` — five agent worktrees were sitting untracked in this repo.
- 11 dead entries dropped from `permissions.allow` (a deleted worktree path, `gh pr comment 36`, three ad-hoc `node -e` probes). 28 kept. From here the list maintains itself.

## Known limits, all deliberate

- **`git` now moves live configuration.** Checking out an older commit rewrites the skills of any running session; `git clean -fdx` deletes them. Documented in `docs/two-paths.md` and the module header. No mitigation exists — it is the price of the shape.
- **Nix cannot template these files.** So `enabledPlugins` and `extraKnownMarketplaces` in `settings.json` are simply David's, including a marketplace at `/Users/david/wmtn/backend/packages/claude`. A hardcoded `/Users/david` path in a committed file is a mild regression against #4, and the honest answer is that Path B cannot express per-host variation. Left as-is and called out; #36's decision 5 is the follow-up.
- **No prompt between typing and versioning.** The activation warns on `env` / `apiKeyHelper` / `awsAuthRefresh` in `settings.json`, which is mitigation rather than a fix.

## Before merging

Not switched on this machine. The first `build-switch` moves the existing `~/.claude/settings.json` and `~/.claude/skills` aside as `.before-nix` and replaces them with the symlinks — worth doing with no Claude Code session running, since it swaps config out from under one.

