### PR TITLE
nix-brew: pass unknown flags through to brew, and lower-case tap keys

### DIFF
--- a/modules/homebrew/nix-brew.sh
+++ b/modules/homebrew/nix-brew.sh
@@ -54,7 +54,16 @@ nix-brew — record Homebrew changes in the nix config instead of only on disk
       --switch      rebuild now (install only; tap/untap always rebuild)
       --no-switch   record only, do not rebuild
 
-Anything else is passed straight through to `brew`.
+A subcommand not listed above is passed straight through to `brew`. So is any
+flag not listed above, for `install` and `uninstall` — `brew install --cask
+--no-quarantine foo` reaches brew intact. `tap` and `untap` do not shell out to
+brew at all (they write the pin and rebuild), so they refuse unknown flags
+rather than pretend to honour them.
+
+One parsing limit: a bare word is read as a package name, so a flag taking a
+space-separated value (`--appdir /Applications`) would swallow the value. Use
+the `--appdir=/Applications` form, or `command brew` for the whole invocation.
+
 Set NIXOS_CONFIG_DIR to point at a checkout other than ~/.config/nixos-config.
 EOF
   exit 2
@@ -83,9 +92,15 @@ GEN_FILE="$REPO/hosts/$HOST/homebrew-generated.nix"
 # `brew tap` names a tap `user/repo`; on disk and in nix-homebrew's attrset it is
 # `user/homebrew-repo`. Normalise once, here, so the rest of the script only
 # deals in the directory form.
+# Lower-cased, because Homebrew downcases tap names internally and looks for
+# `superd22/homebrew-macos-steam` however you typed it. Preserving the input case
+# only works by accident of the default macOS filesystem being case-insensitive,
+# and lets the same tap be recorded twice under two spellings. GitHub is
+# case-insensitive for owner/repo, so fetchFromGitHub does not care.
 tap_key() {
-  local t="$1"
-  [[ "$t" == */* ]] || die "not a tap name: $t (want user/repo)"
+  local t
+  t="$(echo "$1" | tr '[:upper:]' '[:lower:]')"
+  [[ "$t" == */* ]] || die "not a tap name: $1 (want user/repo)"
   local owner="${t%%/*}" repo="${t#*/}"
   [[ "$repo" == homebrew-* ]] || repo="homebrew-$repo"
   echo "${owner}/${repo}"
@@ -187,7 +202,9 @@ cmd_tap() {
     case "$arg" in
       --bump) bump=1 ;;
       --no-switch) switch=0 ;;
-      -*) die "unknown flag for tap: $arg" ;;
+      # tap never shells out to brew — it writes the pin and rebuilds — so there
+      # is nothing to hand a flag to and honouring one would be a lie.
+      -*) die "tap does not take $arg. For brew's own tap, run: command brew tap $*" ;;
       *) target="$arg" ;;
     esac
   done
@@ -249,7 +266,7 @@ cmd_untap() {
   for arg in "$@"; do
     case "$arg" in
       --no-switch) switch=0 ;;
-      -*) die "unknown flag for untap: $arg" ;;
+      -*) die "untap does not take $arg. For brew's own untap, run: command brew untap $*" ;;
       *) target="$arg" ;;
     esac
   done
@@ -282,14 +299,16 @@ ask_disposition() {
 
 cmd_install() {
   local kind=brew disposition="" switch=0
-  local -a names=()
+  local -a names=() extra=()
   for arg in "$@"; do
     case "$arg" in
       --cask|--casks) kind=cask ;;
       -p|--permanent) disposition=permanent ;;
       -s|--scratch) disposition=scratch ;;
       --switch) switch=1 ;;
-      -*) die "unknown flag for install: $arg" ;;
+      # Anything else is brew's, not ours. A wrapper around a command with
+      # dozens of flags has no business rejecting the ones it has not heard of.
+      -*) extra+=("$arg") ;;
       *) names+=("$arg") ;;
     esac
   done
@@ -301,10 +320,19 @@ cmd_install() {
   # Install first: fast feedback, and a declaration for something that does not
   # build is worse than no declaration. The next activation is idempotent.
   if [ "$kind" = cask ]; then
-    command brew install --cask "${names[@]}"
+    command brew install --cask "${extra[@]+"${extra[@]}"}" "${names[@]}"
   else
-    command brew install "${names[@]}"
+    command brew install "${extra[@]+"${extra[@]}"}" "${names[@]}"
   fi
+
+  # brew's own dry run means "change nothing", and the ledger and the generated
+  # file are state like anything else.
+  for arg in "${extra[@]+"${extra[@]}"}"; do
+    if [ "$arg" = "--dry-run" ] || [ "$arg" = "-n" ]; then
+      note "dry run: nothing recorded"
+      return
+    fi
+  done
 
   if [ "$disposition" = scratch ]; then
     for n in "${names[@]}"; do ledger_add "$n"; done
@@ -334,20 +362,20 @@ cmd_install() {
 
 cmd_uninstall() {
   local kind=brew
-  local -a names=()
+  local -a names=() extra=()
   for arg in "$@"; do
     case "$arg" in
       --cask|--casks) kind=cask ;;
-      -*) die "unknown flag for uninstall: $arg" ;;
+      -*) extra+=("$arg") ;;
       *) names+=("$arg") ;;
     esac
   done
   [ "${#names[@]}" -gt 0 ] || usage
 
   if [ "$kind" = cask ]; then
-    command brew uninstall --cask "${names[@]}"
+    command brew uninstall --cask "${extra[@]+"${extra[@]}"}" "${names[@]}"
   else
-    command brew uninstall "${names[@]}"
+    command brew uninstall "${extra[@]+"${extra[@]}"}" "${names[@]}"
   fi
 
   # Uninstalling something that is still declared is a no-op with extra steps:
@@ -369,6 +397,8 @@ cmd_uninstall() {
 
 cmd_drift() {
   local installed
+  # A wrapper-only command; there is no `brew drift` to forward anything to.
+  if [ "$#" -gt 0 ]; then die "drift takes no arguments"; fi
   echo "${YELLOW}formulae installed but not declared${NC}"
   installed="$(command brew leaves | bare_names)"
   comm -23 <(echo "$installed") <(declared brew) | while read -r n; do


### PR DESCRIPTION
Closes #41. Follow-up to #38.

Both defects surfaced while checking whether `brew install --cask crossover` goes through cleanly. It does — these are the edges around it.

## Unknown flags are passed through, not rejected

`brew install --cask --no-quarantine crossover` used to die in the wrapper's argument parser even though brew accepts it and the wrapper shells out to brew anyway. Unknown-flag-means-error is the wrong default for a wrapper around a command with dozens of flags: the wrapper should own only what it defines (`-p`, `-s`, `--switch`, `--no-switch`, `--cask`, `--bump`) and hand the rest over.

Not uniform across commands, because they are not the same kind of thing:

| command | behaviour |
|---|---|
| `install`, `uninstall` | wrap `command brew …`, so unknown flags are collected and forwarded |
| `tap`, `untap` | never shell out to brew — they write the pin and rebuild — so a flag has nothing to be handed to. Still refused, but the error now names the `command brew tap …` to run instead |
| `drift` | wrapper-only, no brew equivalent; rejects arguments outright |

**Dry runs now record nothing.** `--dry-run` / `-n` means change nothing, and the scratch ledger and the generated file are state like anything else. Previously `install -s --dry-run crossover` correctly installed nothing but still wrote a ledger entry.

**Documented limitation:** a bare word is read as a package name, so a flag taking a space-separated value (`--appdir /Applications`) would swallow the value. The help text says so and points at the unambiguous `--appdir=/Applications` form and at `command brew`. Teaching the wrapper brew's argument grammar is not worth it.

## Tap keys are lower-cased

`tap_key` preserved whatever case you typed, so `brew tap Superd22/macos-steam` recorded:

```nix
"Superd22/homebrew-macos-steam" = { owner = "Superd22"; … };
```

while Homebrew downcases tap names internally and looks for `superd22/…`. It worked only because the default macOS filesystem is case-insensitive, and the same tap typed two ways would land as two entries. GitHub is case-insensitive for owner/repo, so `fetchFromGitHub` is unaffected.

**This PR touches only `nix-brew.sh`.** The one existing capitalised entry lives in `modules/homebrew/taps.nix` in the working tree, uncommitted, from the #35 acceptance test — not in `main`. It has been lower-cased in place and left uncommitted alongside the generated brews from that test, so the acceptance test lands as one commit of its own rather than getting entangled with this fix.

## Testing

Both hosts build (shellcheck runs at build time via `writeShellApplication`). Exercised against the real repo:

- `install -s --cask --dry-run crossover` → `==> Would install 1 cask: crossover`, nothing installed, **and nothing recorded**.
- `tap --force superd22/macos-steam` → `tap does not take --force. For brew's own tap, run: command brew tap --force superd22/macos-steam`
- `drift --all` → `drift takes no arguments`
- `tap Superd22/macos-steam` → `superd22/homebrew-macos-steam is already pinned` — the typed capital resolves onto the migrated lower-case key.
- `install -s httpie` → still records to the ledger, so the normal path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
